### PR TITLE
Dictionary values config of VFATs

### DIFF
--- a/chamberInfo.py
+++ b/chamberInfo.py
@@ -34,7 +34,7 @@ GEBtype = {
     9:"long"
     }
 
-chamber_defaults = {
+chamber_vfatDACSettings = {
     #Coffin Setup
     #0: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,},
     #Cosmic Stand

--- a/chamberInfo.py
+++ b/chamberInfo.py
@@ -33,3 +33,21 @@ GEBtype = {
     8:"long",
     9:"long"
     }
+
+chamber_defaults = {
+    #Coffin Setup
+    #0: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,},
+    #Cosmic Stand
+    #0: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,},
+    #Point 5
+    0: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,},
+    1: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,},
+    2: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,},
+    3: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,},
+    4: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,},
+    5: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,},
+    6: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,},
+    7: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,},
+    8: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,},
+    9: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,}
+    }

--- a/confAllChambers.py
+++ b/confAllChambers.py
@@ -3,9 +3,8 @@
 def launch(args):
   return launchArgs(*args)
 
-def launchArgs(shelf,link,slot,run,vt1,vt1bump,config,dictConfig,cName,ztrim):
+def launchArgs(shelf,link,slot,run,vt1,vt1bump,config,cName,ztrim):
     import datetime,os,sys
-    import subprocess
     from subprocess import CalledProcessError
     from chamberInfo import chamber_config
     from gempython.utils.wrappers import runCommand
@@ -21,12 +20,7 @@ def launchArgs(shelf,link,slot,run,vt1,vt1bump,config,dictConfig,cName,ztrim):
 
     if config:
         cmd.append("--vt1bump=%d"%(vt1bump))
-        if options.dictConfig:
-            cmd.append("--dictConfig")
-            pass
-        else:
-            cmd.append("--vfatConfig=%s/configs/z%.1f/vfatConfig_%s.txt"%(dataPath,ztrim,cName))
-            pass
+        cmd.append("--vfatConfig=%s/configs/z%.1f/vfatConfig_%s.txt"%(dataPath,ztrim,cName))
         cmd.append("--chConfig=%s/configs/z%.1f/chConfig_%s.txt"%(dataPath,ztrim,cName))
         pass
     else:
@@ -58,8 +52,6 @@ if __name__ == '__main__':
 
     parser.add_option("--config", action="store_true", dest="config",
                       help="Set Configuration from simple txt files", metavar="config")
-    parser.add_option("--dictConfig", action="store_true", dest="dictConfig", default=False,
-                      help="Configure VFATs to custom chamber_default values", metavar="dictConfig")
     parser.add_option("--run", action="store_true", dest="run",
                       help="Set VFATs to run mode", metavar="run")
     parser.add_option("--series", action="store_true", dest="series",
@@ -83,7 +75,6 @@ if __name__ == '__main__':
                         [options.vt1bump   for x in range(len(chamber_config))],
                         [options.config    for x in range(len(chamber_config))],
                         [chamber_config[x] for x in chamber_config.keys()],
-                        [options.dictConfig for x in range(len(chamber_config))],
                         [options.ztrim     for x in range(len(chamber_config))],
                   )
             )
@@ -92,7 +83,7 @@ if __name__ == '__main__':
         print "Configuring chambers in serial mode"
         for link in chamber_config.keys():
             chamber = chamber_config[link]
-            launchArgs(options.shelf,link,options.slot,options.run,options.vt1,options.vt1bump,options.config,options.dictConfig,chamber,options.ztrim)
+            launchArgs(options.shelf,link,options.slot,options.run,options.vt1,options.vt1bump,options.config,chamber,options.ztrim)
             pass
         pass
     else:
@@ -111,7 +102,6 @@ if __name__ == '__main__':
                                                 [options.vt1bump   for x in range(len(chamber_config))],
                                                 [options.config    for x in range(len(chamber_config))],
                                                 [chamber_config[x] for x in chamber_config.keys()],
-                                                [options.dictConfig  for x in range(len(chamber_config))],
                                                 [options.ztrim     for x in range(len(chamber_config))],
                                                 )
                                  )

--- a/confAllChambers.py
+++ b/confAllChambers.py
@@ -3,7 +3,7 @@
 def launch(args):
   return launchArgs(*args)
 
-def launchArgs(shelf,link,slot,run,vt1,vt1bump,config,cName,ztrim):
+def launchArgs(shelf,link,slot,run,vt1,vt1bump,config,dictConfig,cName,ztrim):
     import datetime,os,sys
     import subprocess
     from subprocess import CalledProcessError
@@ -21,8 +21,14 @@ def launchArgs(shelf,link,slot,run,vt1,vt1bump,config,cName,ztrim):
 
     if config:
         cmd.append("--vt1bump=%d"%(vt1bump))
-        cmd.append("--vfatConfig=%s/configs/z%.1f/vfatConfig_%s.txt"%(dataPath,ztrim,cName))
+        if options.dictConfig:
+            cmd.append("--dictConfig")
+            pass
+        else:
+            cmd.append("--vfatConfig=%s/configs/z%.1f/vfatConfig_%s.txt"%(dataPath,ztrim,cName))
+            pass
         cmd.append("--chConfig=%s/configs/z%.1f/chConfig_%s.txt"%(dataPath,ztrim,cName))
+        pass
     else:
         if not os.path.isfile(filename):
             print "No trim configuration exists for z = %f for %s"%(ztrim,cName)
@@ -52,6 +58,8 @@ if __name__ == '__main__':
 
     parser.add_option("--config", action="store_true", dest="config",
                       help="Set Configuration from simple txt files", metavar="config")
+    parser.add_option("--dictConfig", action="store_true", dest="dictConfig", default=False,
+                      help="Configure VFATs to custom chamber_default values", metavar="dictConfig")
     parser.add_option("--run", action="store_true", dest="run",
                       help="Set VFATs to run mode", metavar="run")
     parser.add_option("--series", action="store_true", dest="series",
@@ -75,6 +83,7 @@ if __name__ == '__main__':
                         [options.vt1bump   for x in range(len(chamber_config))],
                         [options.config    for x in range(len(chamber_config))],
                         [chamber_config[x] for x in chamber_config.keys()],
+                        [options.dictConfig for x in range(len(chamber_config))],
                         [options.ztrim     for x in range(len(chamber_config))],
                   )
             )
@@ -83,7 +92,7 @@ if __name__ == '__main__':
         print "Configuring chambers in serial mode"
         for link in chamber_config.keys():
             chamber = chamber_config[link]
-            launchArgs(options.shelf,link,options.slot,options.run,options.vt1,options.vt1bump,options.config,chamber,options.ztrim)
+            launchArgs(options.shelf,link,options.slot,options.run,options.vt1,options.vt1bump,options.config,options.dictConfig,chamber,options.ztrim)
             pass
         pass
     else:
@@ -102,6 +111,7 @@ if __name__ == '__main__':
                                                 [options.vt1bump   for x in range(len(chamber_config))],
                                                 [options.config    for x in range(len(chamber_config))],
                                                 [chamber_config[x] for x in chamber_config.keys()],
+                                                [options.dictConfig  for x in range(len(chamber_config))],
                                                 [options.ztrim     for x in range(len(chamber_config))],
                                                 )
                                  )

--- a/confChamber.py
+++ b/confChamber.py
@@ -6,22 +6,23 @@ By: Cameron Bravo c.bravo@cern.ch
 
 from array import array
 from gempython.tools.vfat_user_functions_uhal import *
-
+from chamberInfo import chamber_defaults
 from qcoptions import parser
 
-parser.add_option("--filename", type="string", dest="filename", default=None,
-                  help="Specify file containing settings information", metavar="filename")
 parser.add_option("--chConfig", type="string", dest="chConfig", default=None,
                   help="Specify file containing channel settings from anaUltraSCurve", metavar="chConfig")
+parser.add_option("--dictConfig", action="store_true", dest="dictConfig", default=False,
+                  help="Configure VFATs to custom chamber_default values", metavar="dictConfig")
+parser.add_option("--filename", type="string", dest="filename", default=None,
+                  help="Specify file containing settings information", metavar="filename")
+parser.add_option("--run", action="store_true", dest="run",
+                  help="Set VFATs to run mode", metavar="run")
 parser.add_option("--vfatConfig", type="string", dest="vfatConfig", default=None,
                   help="Specify file containing VFAT settings from anaUltraThreshold", metavar="vfatConfig")
 parser.add_option("--vt1", type="int", dest="vt1",
                   help="VThreshold1 DAC value for all VFATs", metavar="vt1", default=100)
 parser.add_option("--vt1bump", type="int", dest="vt1bump",
                   help="VThreshold1 DAC bump value for all VFATs", metavar="vt1bump", default=0)
-parser.add_option("--run", action="store_true", dest="run",
-                  help="Set VFATs to run mode", metavar="run")
-
 
 (options, args) = parser.parse_args()
 
@@ -87,5 +88,20 @@ if options.vfatConfig:
     except Exception as e:
         print '%s does not seem to exist'%options.filename
         print e
-print 'Chamber Configured'
 
+if options.dictConfig:
+    try:
+        print "Configuring VFATs with dictionary values"
+
+        for x in range (len(chamber_defaults)):
+            writeAllVFATs(ohboard, options.gtx, "IPreampIn", chamber_defaults[x]["IPreampIn"], 0)
+            writeAllVFATs(ohboard, options.gtx, "IPreampFeed", chamber_defaults[x]["IPreampFeed"], 0)
+            writeAllVFATs(ohboard, options.gtx, "IPreampOut", chamber_defaults[x]["IPreampOut"], 0)
+            writeAllVFATs(ohboard, options.gtx, "IShaper", chamber_defaults[x]["IShaper"], 0)
+            writeAllVFATs(ohboard, options.gtx, "IShaperFeed", chamber_defaults[x]["IShaperFeed"], 0)
+            writeAllVFATs(ohboard, options.gtx, "IComp", chamber_defaults[x]["IComp"], 0)
+    except Exception as e:
+        print 'Error configuring the VFATs with dictionary values'
+        print e
+
+print 'Chamber Configured'

--- a/confChamber.py
+++ b/confChamber.py
@@ -6,13 +6,11 @@ By: Cameron Bravo c.bravo@cern.ch
 
 from array import array
 from gempython.tools.vfat_user_functions_uhal import *
-from chamberInfo import chamber_defaults
+from chamberInfo import chamber_vfatDACSettings
 from qcoptions import parser
 
 parser.add_option("--chConfig", type="string", dest="chConfig", default=None,
                   help="Specify file containing channel settings from anaUltraSCurve", metavar="chConfig")
-parser.add_option("--dictConfig", action="store_true", dest="dictConfig", default=False,
-                  help="Configure VFATs to custom chamber_default values", metavar="dictConfig")
 parser.add_option("--filename", type="string", dest="filename", default=None,
                   help="Specify file containing settings information", metavar="filename")
 parser.add_option("--run", action="store_true", dest="run",
@@ -89,19 +87,17 @@ if options.vfatConfig:
         print '%s does not seem to exist'%options.filename
         print e
 
-if options.dictConfig:
+if options.gtx in chamber_vfatDACSettings.keys():
     try:
-        print "Configuring VFATs with dictionary values"
-
-        for x in range (len(chamber_defaults)):
-            writeAllVFATs(ohboard, options.gtx, "IPreampIn", chamber_defaults[x]["IPreampIn"], 0)
-            writeAllVFATs(ohboard, options.gtx, "IPreampFeed", chamber_defaults[x]["IPreampFeed"], 0)
-            writeAllVFATs(ohboard, options.gtx, "IPreampOut", chamber_defaults[x]["IPreampOut"], 0)
-            writeAllVFATs(ohboard, options.gtx, "IShaper", chamber_defaults[x]["IShaper"], 0)
-            writeAllVFATs(ohboard, options.gtx, "IShaperFeed", chamber_defaults[x]["IShaperFeed"], 0)
-            writeAllVFATs(ohboard, options.gtx, "IComp", chamber_defaults[x]["IComp"], 0)
+        print "Configuring VFATs with chamber_vfatDACSettings dictionary values"
+        writeAllVFATs(ohboard, options.gtx, "IPreampIn", chamber_vfatDACSettings[options.gtx]["IPreampIn"], 0)
+        writeAllVFATs(ohboard, options.gtx, "IPreampFeed", chamber_vfatDACSettings[options.gtx]["IPreampFeed"], 0)
+        writeAllVFATs(ohboard, options.gtx, "IPreampOut", chamber_vfatDACSettings[options.gtx]["IPreampOut"], 0)
+        writeAllVFATs(ohboard, options.gtx, "IShaper", chamber_vfatDACSettings[options.gtx]["IShaper"], 0)
+        writeAllVFATs(ohboard, options.gtx, "IShaperFeed", chamber_vfatDACSettings[options.gtx]["IShaperFeed"], 0)
+        writeAllVFATs(ohboard, options.gtx, "IComp", chamber_vfatDACSettings[options.gtx]["IComp"], 0)
     except Exception as e:
-        print 'Error configuring the VFATs with dictionary values'
+        print 'Error configuring the VFATs with chamber_vfatDACSettings dictionary values'
         print e
 
 print 'Chamber Configured'

--- a/confChamber.py
+++ b/confChamber.py
@@ -2,6 +2,7 @@
 """
 Script to configure the VFATs on a GEM chamber
 By: Cameron Bravo c.bravo@cern.ch
+Modified by: Eklavya Sarkar eklavya.sarkar@cern.ch
 """
 
 from array import array


### PR DESCRIPTION
Addressing:

#86

Added `chamber_vfatDACSettings` dictionary in `ChamberInfo.py`, such as :

```chamber_vfatDACSettings = {
    #Cosmic Stand
    0: {"IPreampIn": 168, "IPreampFeed": 80, "IPreampOut": 150, "IShaper": 150, "IShaperFeed": 100, "IComp": 90,}
    } 
```

Note: the above shows only the relevant bit for the cosmic stand with the g0 link. Same lines have been added for the P5 and COFFIN as well. To use adequately one should make sure the other irrelevant parts are duly commented-out.

 Updated `confChamber.py` by:

Adding an if-structure that would use the `writeAllVFATs` function to overwrite the default values (written by the `biasAllVFATs` method) if the link provided as an argument exists in the `chamber_vfatDACSettings` dictionary, and reconfigure the chamber’s IPreampIn, IPreampFeed, IPreampOut, IShaper, IShaperFeed and IComp values.

Usage example (for cosmic stand):

`confAllChambers.py --shelf=3 -s2 -g0 --config`

`confChamber.py -s2 -g0 --shelf=3`

Changes the VFAT parameters are expected. Can be seen using `vfat_info_uhal.py -s2 -g0 --shelf=3` (for cosmic stand).

Tested and confirmed to work:
 
http://cmsonline.cern.ch/cms-elog/1003518

--

Older versions of tests can be found at:

http://cmsonline.cern.ch/cms-elog/999820
http://cmsonline.cern.ch/cms-elog/999477

(Note: these last 2 e-logs above used a --dictConfig or --ccc flag to enable dictionary values. Since then, the code has been updated to automatically use the dictionary values if the provided link exists in the dictionary, therefore rendering the flags and the shown usage in logs outdated).