### PR TITLE
Fixed a bug where default MSPL was set incorrectly

### DIFF
--- a/qcoptions.py
+++ b/qcoptions.py
@@ -1,7 +1,7 @@
 from gempython.utils.standardopts import parser
 
-parser.add_option("--mspl", type="int", dest = "MSPL", default = 1,
-                  help="Specify MSPL. Must be in the range 1-8 (default is 1)", metavar="MSPL")
+parser.add_option("--mspl", type="int", dest = "MSPL", default = 4,
+                  help="Specify MSPL. Must be in the range 1-8 (default is 4)", metavar="MSPL")
 parser.add_option("--nevts", type="int", dest="nevts",
                   help="Number of events to count at each scan point", metavar="nevts", default=1000)
 parser.add_option("--scanmin", type="int", dest="scanmin",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addressing:
https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/114

Changing default MSPL value in qcoptions.py from 1 (incorrect) to 4 (correct)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Addressing problems observed in:
http://cmsonline.cern.ch/cms-elog/1004380

Scurves suffer from timing problems with mspl=1 and cannot be used for trimming or analysis.
<!--- If it fixes an open issue, please link to the issue(s) here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Testing performed by myself and @lmoureaux at:
http://cmsonline.cern.ch/cms-elog/1004358
http://cmsonline.cern.ch/cms-elog/1004364
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):
<img width="1076" alt="summary" src="https://user-images.githubusercontent.com/6432141/29373804-97a11730-82af-11e7-83bb-aa0bdfd8a155.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
