### PR TITLE
Addressing issue #117

### DIFF
--- a/run_scans.py
+++ b/run_scans.py
@@ -21,7 +21,7 @@ def launchTestsArgs(tool, shelf, slot, link, chamber, vfatmask, scanmin, scanmax
 
   #Build Commands
   setupCmds = []
-  preCmd = None 
+  preCmd = None
   cmd = ["%s"%(tool),"-s%i"%(slot),"-g%i"%(link),"--shelf=%i"%(shelf), "--nevts=%i"%(nevts), "--vfatmask=0x%x"%(vfatmask)]
   if tool == "ultraScurve.py":
     scanType = "scurve"
@@ -132,11 +132,9 @@ def launchTestsArgs(tool, shelf, slot, link, chamber, vfatmask, scanmin, scanmax
       pass
     log = file("%s/scanLog.log"%(dirPath),"w")
     if preCmd and config:
-      #runCommand(preCmd,log)
-      runCommand(preCmd)
+      runCommand(preCmd,log)
       pass
-    #runCommand(cmd,log)
-    runCommand(cmd)
+    runCommand(cmd,log)
   except CalledProcessError as e:
     print "Caught exception",e
     pass
@@ -197,7 +195,7 @@ if __name__ == '__main__':
                          [options.slot for x in range(len(chamber_config))],
                          chamber_config.keys(),
                          chamber_config.values(),
-                         chamber_vfatMask.values(),
+                         [hex(vfatmask) for vfatmask in chamber_vfatMask.values()],
                          [options.scanmin for x in range(len(chamber_config))],
                          [options.scanmax for x in range(len(chamber_config))], 
                          [options.nevts   for x in range(len(chamber_config))],

--- a/run_scans.py
+++ b/run_scans.py
@@ -21,7 +21,7 @@ def launchTestsArgs(tool, shelf, slot, link, chamber, vfatmask, scanmin, scanmax
 
   #Build Commands
   setupCmds = []
-  preCmd = None
+  preCmd = ["confChamber.py","-s%i"%(slot),"-g%i"%(link),"--shelf=%i"%(shelf)]
   cmd = ["%s"%(tool),"-s%i"%(slot),"-g%i"%(link),"--shelf=%i"%(shelf), "--nevts=%i"%(nevts), "--vfatmask=0x%x"%(vfatmask)]
   if tool == "ultraScurve.py":
     scanType = "scurve"
@@ -34,7 +34,6 @@ def launchTestsArgs(tool, shelf, slot, link, chamber, vfatmask, scanmin, scanmax
     cmd.append( "--filename=%s/SCurveData.root"%dirPath )
     if mspl:
       cmd.append( "--mspl=%i"%(mspl) )
-    preCmd = ["confChamber.py","-s%i"%(slot),"-g%i"%(link)]
     if vt1 in range(256):
       preCmd.append("--vt1=%i"%(vt1))
       pass
@@ -42,7 +41,6 @@ def launchTestsArgs(tool, shelf, slot, link, chamber, vfatmask, scanmin, scanmax
   elif tool == "trimChamber.py":
     scanType = "trim"
     dataType = None
-    preCmd = ["confChamber.py","-s%i"%(slot),"-g%i"%(link)]
     if vt1 in range(256):
       preCmd.append("--vt1=%i"%(vt1))
       pass
@@ -132,7 +130,8 @@ def launchTestsArgs(tool, shelf, slot, link, chamber, vfatmask, scanmin, scanmax
       pass
     log = file("%s/scanLog.log"%(dirPath),"w")
     if preCmd and config:
-      runCommand(preCmd,log)
+      #runCommand(preCmd,log)
+      runCommand(preCmd)
       pass
     #runCommand(cmd,log)
     runCommand(cmd)

--- a/run_scans.py
+++ b/run_scans.py
@@ -21,7 +21,7 @@ def launchTestsArgs(tool, shelf, slot, link, chamber, vfatmask, scanmin, scanmax
 
   #Build Commands
   setupCmds = []
-  preCmd = ["confChamber.py","-s%i"%(slot),"-g%i"%(link),"--shelf=%i"%(shelf)]
+  preCmd = None 
   cmd = ["%s"%(tool),"-s%i"%(slot),"-g%i"%(link),"--shelf=%i"%(shelf), "--nevts=%i"%(nevts), "--vfatmask=0x%x"%(vfatmask)]
   if tool == "ultraScurve.py":
     scanType = "scurve"
@@ -34,6 +34,7 @@ def launchTestsArgs(tool, shelf, slot, link, chamber, vfatmask, scanmin, scanmax
     cmd.append( "--filename=%s/SCurveData.root"%dirPath )
     if mspl:
       cmd.append( "--mspl=%i"%(mspl) )
+    preCmd = ["confChamber.py","-s%i"%(slot),"-g%i"%(link),"--shelf=%i"%(shelf)]
     if vt1 in range(256):
       preCmd.append("--vt1=%i"%(vt1))
       pass
@@ -41,6 +42,7 @@ def launchTestsArgs(tool, shelf, slot, link, chamber, vfatmask, scanmin, scanmax
   elif tool == "trimChamber.py":
     scanType = "trim"
     dataType = None
+    preCmd = ["confChamber.py","-s%i"%(slot),"-g%i"%(link),"--shelf=%i"%(shelf)]
     if vt1 in range(256):
       preCmd.append("--vt1=%i"%(vt1))
       pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Addressing https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/117.

`run_scans.py` will now properly pass the `--shelf` argument to the `preCmd` when the `--config` option is used.
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See above.  The above issue would prevent scans from being taken with the correct configuration.
<!--- If it fixes an open issue, please link to the issue(s) here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tests performed here: http://cmsonline.cern.ch/cms-elog/1005139

And analyzed here: http://cmsonline.cern.ch/cms-elog/1005447

The `--shelf=3` option was properly passed with calling the `--config` option when using commit: 56476318321bb01d254094c9631cd69285659935.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):
<img width="1078" alt="summary_vt1_20" src="https://user-images.githubusercontent.com/6432141/29576377-e247a882-8767-11e7-89a3-f619f6b99287.png">
<img width="1077" alt="fitsummary_vt1_20" src="https://user-images.githubusercontent.com/6432141/29576378-e24966a4-8767-11e7-9b3a-37cad866d467.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
