### PR TITLE
Addressing issue #116

### DIFF
--- a/confChamber.py
+++ b/confChamber.py
@@ -39,6 +39,15 @@ Date = startTime
 ohboard = getOHObject(options.slot,options.gtx,options.shelf)
 print 'opened connection'
 
+if options.gtx in chamber_vfatDACSettings.keys():
+    print "Configuring VFATs with chamber_vfatDACSettings dictionary values"
+    parameters.defaultValues["IPreampIn"] = chamber_vfatDACSettings[options.gtx]["IPreampIn"]
+    parameters.defaultValues["IPreampFeed"] = chamber_vfatDACSettings[options.gtx]["IPreampFeed"]
+    parameters.defaultValues["IPreampOut"] = chamber_vfatDACSettings[options.gtx]["IPreampOut"]
+    parameters.defaultValues["IShaper"] = chamber_vfatDACSettings[options.gtx]["IShaper"]
+    parameters.defaultValues["IShaperFeed"] = chamber_vfatDACSettings[options.gtx]["IShaperFeed"]
+    parameters.defaultValues["IComp"] = chamber_vfatDACSettings[options.gtx]["IComp"]
+
 biasAllVFATs(ohboard,options.gtx,0x0,enable=False)
 print 'biased VFATs'
 writeAllVFATs(ohboard, options.gtx, "VThreshold1", options.vt1, 0)
@@ -86,19 +95,6 @@ if options.vfatConfig:
             writeVFAT(ohboard, options.gtx, int(event.vfatN), "ContReg3", int(event.trimRange),0)
     except Exception as e:
         print '%s does not seem to exist'%options.filename
-        print e
-
-if options.gtx in chamber_vfatDACSettings.keys():
-    try:
-        print "Configuring VFATs with chamber_vfatDACSettings dictionary values"
-        writeAllVFATs(ohboard, options.gtx, "IPreampIn", chamber_vfatDACSettings[options.gtx]["IPreampIn"], 0)
-        writeAllVFATs(ohboard, options.gtx, "IPreampFeed", chamber_vfatDACSettings[options.gtx]["IPreampFeed"], 0)
-        writeAllVFATs(ohboard, options.gtx, "IPreampOut", chamber_vfatDACSettings[options.gtx]["IPreampOut"], 0)
-        writeAllVFATs(ohboard, options.gtx, "IShaper", chamber_vfatDACSettings[options.gtx]["IShaper"], 0)
-        writeAllVFATs(ohboard, options.gtx, "IShaperFeed", chamber_vfatDACSettings[options.gtx]["IShaperFeed"], 0)
-        writeAllVFATs(ohboard, options.gtx, "IComp", chamber_vfatDACSettings[options.gtx]["IComp"], 0)
-    except Exception as e:
-        print 'Error configuring the VFATs with chamber_vfatDACSettings dictionary values'
         print e
 
 print 'Chamber Configured'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addressing https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/116.

Optimization of configuration procedure.  Before default settings were applied in `confChamber.py` with a call to `biasAllVFATs` and then afterward non-default parameters found in the `chamber_vfatDACSettings` dictionary of `gem-plotting-tools/mapping/chamberInfo.py`. This lead to additional (unnecessary write actions).

Now the non-default parameters of `chamber_vfatDACSettings` are stored in `parameters.defaultValues` (defined in `vfat_info_uhal.py`) before the call to `biasAllVFATs`.  This ensures the non-default parameters are correctly applied with only a reduced number of register write actions. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Optimization (request for change which improves functionality)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Previously `confChamber.py` was making too many unnecessary function calls to configure the electronics.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing documented in: http://cmsonline.cern.ch/cms-elog/1005597

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
