### PR TITLE
New Feature: Cross-Check of Registers in confChamber.py (#122)

### DIFF
--- a/confChamber.py
+++ b/confChamber.py
@@ -26,6 +26,8 @@ parser.add_option("--vt1", type="int", dest="vt1",
                   help="VThreshold1 DAC value for all VFATs", metavar="vt1", default=100)
 parser.add_option("--vt1bump", type="int", dest="vt1bump",
                   help="VThreshold1 DAC bump value for all VFATs", metavar="vt1bump", default=0)
+#parser.add_option("-w","--write",action="store_true", dest="write",
+#                  help="Write the current settings to a file", metavar="write")
 
 (options, args) = parser.parse_args()
 
@@ -71,6 +73,12 @@ if options.filename:
         for event in inF.scurveFitTree :
             writeVFAT(ohboard,options.gtx,int(event.vfatN),"VFATChannels.ChanReg%d"%(int(event.vfatCH)),int(event.trimDAC)+32*int(event.mask))
             writeVFAT(ohboard, options.gtx, int(event.vfatN), "ContReg3", int(event.trimRange),0)
+        
+        if options.verify:
+            chTree = inF.Get("scurveFitTree")
+            dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg" }
+            readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
+
     except Exception as e:
         print '%s does not seem to exist'%options.filename
         print e
@@ -83,6 +91,11 @@ if options.chConfig:
 
         for event in chTree :
             writeVFAT(ohboard,options.gtx,int(event.vfatN),"VFATChannels.ChanReg%d"%(int(event.vfatCH)),int(event.trimDAC)+32*int(event.mask))
+        
+        if options.verify:
+            dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg" }
+            readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
+
     except Exception as e:
         print '%s does not seem to exist'%options.filename
         print e
@@ -98,14 +111,14 @@ if options.vfatConfig:
             writeVFAT(ohboard, options.gtx, int(event.vfatN), "VThreshold1", int(event.vt1+options.vt1bump),0)
             writeVFAT(ohboard, options.gtx, int(event.vfatN), "ContReg3", int(event.trimRange),0)
 
+        if options.verify:
+            if options.vt1bump != 0:
+                print "Mismatches between write & readback valus for VThreshold1 should be exactly %i" %(options.vt1bump)
+            dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3" }
+            readBackCheck(vfatTree, dict_readBack, ohboard, options.gtx)
+
     except Exception as e:
         print '%s does not seem to exist'%options.filename
         print e
         
-if options.verify:
-    if options.vt1bump != 0:
-        print "Mismatches between write & readback valus for VThreshold1 should be exactly %i" %(options.vt1bump)
-    dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3" }
-    readBackCheck(vfatTree, dict_readBack, ohboard, options.gtx)
-
 print 'Chamber Configured'

--- a/confChamber.py
+++ b/confChamber.py
@@ -70,18 +70,15 @@ if options.filename:
         chTree = inF.Get("scurveFitTree")
         dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg" }
 
-        if options.compare:
-            print 'Comparing Currently Stored Channel Registers with %s'%options.filename
-
-            readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
-        else:
+        if not options.compare:
             print 'Configuring Channel Registers based on %s'%options.filename
             
-            for event in inF.scurveFitTree :
+            for event in inF.scurveFitTree:
                 writeVFAT(ohboard,options.gtx,int(event.vfatN),"VFATChannels.ChanReg%d"%(int(event.vfatCH)),int(event.trimDAC)+32*int(event.mask))
                 writeVFAT(ohboard, options.gtx, int(event.vfatN), "ContReg3", int(event.trimRange),0)
-        
-            readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
+ 
+        print 'Comparing Currently Stored Channel Registers with %s'%options.filename
+        readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
 
     except Exception as e:
         print '%s does not seem to exist'%options.filename
@@ -93,17 +90,14 @@ if options.chConfig:
         chTree.ReadFile(options.chConfig)
         dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg" }
 
-        if options.compare:
-            print 'Comparing Currently Stored Channel Registers with %s'%options.chConfig
-            
-            readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
-        else:
+        if not options.compare:
             print 'Configuring Channel Registers based on %s'%options.chConfig
             
             for event in chTree :
                 writeVFAT(ohboard,options.gtx,int(event.vfatN),"VFATChannels.ChanReg%d"%(int(event.vfatCH)),int(event.trimDAC)+32*int(event.mask))
-            
-            readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
+        
+        print 'Comparing Currently Stored Channel Registers with %s'%options.chConfig
+        readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
 
     except Exception as e:
         print '%s does not seem to exist'%options.filename
@@ -115,25 +109,18 @@ if options.vfatConfig:
         vfatTree.ReadFile(options.vfatConfig)
         dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3" }
 
-        if options.compare:
-            print 'Comparing Curently Stored VFAT Registers with %s'%options.vfatConfig
-
-            if options.vt1bump != 0:
-                print "Mismatches between write & readback valus for VThreshold1 should be exactly %i" %(options.vt1bump)
-            
-            readBackCheck(vfatTree, dict_readBack, ohboard, options.gtx)
-        else:
+        if not options.compare:
             print 'Configuring VFAT Registers based on %s'%options.vfatConfig
 
             for event in vfatTree :
                 print 'Set link %d VFAT%d VThreshold1 to %i'%(options.gtx,event.vfatN,event.vt1+options.vt1bump)
                 writeVFAT(ohboard, options.gtx, int(event.vfatN), "VThreshold1", int(event.vt1+options.vt1bump),0)
                 writeVFAT(ohboard, options.gtx, int(event.vfatN), "ContReg3", int(event.trimRange),0)
-            
-            if options.vt1bump != 0:
-                print "Mismatches between write & readback valus for VThreshold1 should be exactly %i" %(options.vt1bump)
-            
-            readBackCheck(vfatTree, dict_readBack, ohboard, options.gtx)
+        
+        print 'Comparing Curently Stored VFAT Registers with %s'%options.vfatConfig
+        if options.vt1bump != 0:
+            print "Mismatches between write & readback valus for VThreshold1 should be exactly %i" %(options.vt1bump)
+        readBackCheck(vfatTree, dict_readBack, ohboard, options.gtx)
 
     except Exception as e:
         print '%s does not seem to exist'%options.filename

--- a/confChamber.py
+++ b/confChamber.py
@@ -98,14 +98,14 @@ if options.vfatConfig:
             writeVFAT(ohboard, options.gtx, int(event.vfatN), "VThreshold1", int(event.vt1+options.vt1bump),0)
             writeVFAT(ohboard, options.gtx, int(event.vfatN), "ContReg3", int(event.trimRange),0)
 
-        if options.verify:
-            if options.vt1bump > 0:
-                print "Mismatches between write & readback valus for VThreshold1 should be exactly %i" %(options.vt1bump)
-            dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3" }
-            readBackCheck(vfatTree, dict_readBack, ohboard, options.gtx)
-
     except Exception as e:
         print '%s does not seem to exist'%options.filename
         print e
+        
+if options.verify:
+    if options.vt1bump != 0:
+        print "Mismatches between write & readback valus for VThreshold1 should be exactly %i" %(options.vt1bump)
+    dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3" }
+    readBackCheck(vfatTree, dict_readBack, ohboard, options.gtx)
 
 print 'Chamber Configured'

--- a/confChamber.py
+++ b/confChamber.py
@@ -54,8 +54,9 @@ if options.gtx in chamber_vfatDACSettings.keys():
 
 biasAllVFATs(ohboard,options.gtx,0x0,enable=False)
 print 'biased VFATs'
-writeAllVFATs(ohboard, options.gtx, "VThreshold1", options.vt1, 0)
-print 'Set VThreshold1 to %i'%options.vt1
+if not options.compare:
+    writeAllVFATs(ohboard, options.gtx, "VThreshold1", options.vt1, 0)
+    print 'Set VThreshold1 to %i'%options.vt1
 
 if options.run:
     writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x37,        0)

--- a/qcutilities.py
+++ b/qcutilities.py
@@ -1,0 +1,38 @@
+from gempython.tools.vfat_user_functions_uhal import *
+
+import numpy as np
+import root_numpy as rp
+import ROOT as r
+import sys
+
+# rootTree - name of a TTree that has values that should have been written
+# dict_Names - dictionary where key names are the branch names in rootTree and the values are the register names they correspond too
+# device - optohybrid  the vfats belong to that you want to check
+# gtx - link of this optohybrid
+def readBackCheck(rootTree, dict_Names, device, gtx):
+    # Check that the requested register is supported
+    list_KnownRegs = parameters.defaultValues.keys()
+    list_KnownRegs.append("VThreshold1")
+    for regName in dict_Names.values():
+        if regName not in list_KnownRegs:
+            print "readBackCheck() does not understand %s"%(regName)
+            print "readBackCheck() is only supported for registers:", list_KnownRegs
+            sys.exit(-1)
+
+    # Get data from tree
+    list_bNames = dict_Names.keys()
+    list_bNames.append('vfatN')
+    array_writeVals = rp.tree2array(tree=rootTree, branches=list_bNames)
+
+    # Get data from VFATs
+    perreg   = "0x%02x"
+    for bName,regName in dict_Names.iteritems():
+        print "Reading back %s from all VFATs, any potential mismatches will be reported below"%(regName)
+        print "="*40
+        regValues = readAllVFATs(device, gtx, regName, 0x0)
+        regMap = map(lambda chip: chip&0xff, regValues)
+        for vfat,readBackVal in enumerate(regMap):
+            writeValsPerVFAT = array_writeVals[ array_writeVals['vfatN'] == vfat]
+            writeValOfReg = np.asscalar(writeValsPerVFAT['%s'%bName])
+            if writeValOfReg != readBackVal:
+                print "VFAT%i: %s mismatch, write val = %i, readback = %i"%(vfat, regName, writeValOfReg, readBackVal)

--- a/qcutilities.py
+++ b/qcutilities.py
@@ -5,11 +5,16 @@ import root_numpy as rp
 import ROOT as r
 import sys
 
-# rootTree - name of a TTree that has values that should have been written
-# dict_Names - dictionary where key names are the branch names in rootTree and the values are the register names they correspond too
-# device - optohybrid  the vfats belong to that you want to check
-# gtx - link of this optohybrid
 def readBackCheck(rootTree, dict_Names, device, gtx):
+    """
+    Given an input set of registers, and expected values of those registers, read from all VFATs on device.gtx to see if there are any differences between written and read values.
+
+    rootTree - name of a TTree that has values that should have been written
+    dict_Names - dictionary where key names are the branch names in rootTree and the values are the register names they correspond too
+    device - optohybrid the vfats belong to that you want to check
+    gtx - link of this optohybrid
+    """
+    
     # Check that the requested register is supported
     list_KnownRegs = parameters.defaultValues.keys()
     list_KnownRegs.append("VThreshold1")

--- a/qcutilities.py
+++ b/qcutilities.py
@@ -18,6 +18,7 @@ def readBackCheck(rootTree, dict_Names, device, gtx):
     # Check that the requested register is supported
     list_KnownRegs = parameters.defaultValues.keys()
     list_KnownRegs.append("VThreshold1")
+    list_KnownRegs.append("VFATChannels.ChanReg")
     for regName in dict_Names.values():
         if regName not in list_KnownRegs:
             print "readBackCheck() does not understand %s"%(regName)
@@ -27,17 +28,41 @@ def readBackCheck(rootTree, dict_Names, device, gtx):
     # Get data from tree
     list_bNames = dict_Names.keys()
     list_bNames.append('vfatN')
+    if "trimDAC" in dict_Names.keys() or "mask" in dict_Names.keys():
+        list_bNames.append('vfatCH')
     array_writeVals = rp.tree2array(tree=rootTree, branches=list_bNames)
 
     # Get data from VFATs
     perreg   = "0x%02x"
     for bName,regName in dict_Names.iteritems():
-        print "Reading back %s from all VFATs, any potential mismatches will be reported below"%(regName)
+        print "Reading back (%s,%s) from all VFATs, any potential mismatches will be reported below"%(bName,regName)
         print "="*40
-        regValues = readAllVFATs(device, gtx, regName, 0x0)
-        regMap = map(lambda chip: chip&0xff, regValues)
-        for vfat,readBackVal in enumerate(regMap):
-            writeValsPerVFAT = array_writeVals[ array_writeVals['vfatN'] == vfat]
-            writeValOfReg = np.asscalar(writeValsPerVFAT['%s'%bName])
-            if writeValOfReg != readBackVal:
-                print "VFAT%i: %s mismatch, write val = %i, readback = %i"%(vfat, regName, writeValOfReg, readBackVal)
+        
+        regMap = []
+        regValues = []
+        if regName == "VFATChannels.ChanReg": #Channel Register, use 0x1f
+            for chan in range(0,128):
+                regValues = readAllVFATs(device, gtx, regName+"%d"%(chan), 0x0)
+                #regMap = map(lambda chip: chip&0x1f, regValues)
+                
+                for vfat,readBackVal in enumerate(regValues):
+                    writeValsPerVFAT = array_writeVals[ array_writeVals['vfatN'] == vfat]
+                    writeValsPerVFAT = writeValsPerVFAT[ writeValsPerVFAT['vfatCH'] == chan]
+                    writeValOfReg = np.asscalar(writeValsPerVFAT['%s'%bName]) 
+                    if bName == "mask":
+                        if writeValOfReg != ((readBackVal&0x20)%31): #trimDAC goes from 0 -> 31, leftover is mask
+                            print "VFAT%i Chan%i: %s mismatch, write val = %i, readback = %i"%(vfat, chan, bName, writeValOfReg, (readBackVal&0x20)%31)
+                    else:
+                        if writeValOfReg != (readBackVal&0x1f):
+                            print "VFAT%i Chan%i: %s mismatch, write val = %i, readback = %i"%(vfat, chan, bName, writeValOfReg, readBackVal&0x1f)
+        else: #VFAT Register, use 0xff
+            regValues = readAllVFATs(device, gtx, regName, 0x0)
+            regMap = map(lambda chip: chip&0xff, regValues)
+
+            for vfat,readBackVal in enumerate(regMap):
+                writeValsPerVFAT = array_writeVals[ array_writeVals['vfatN'] == vfat]
+                writeValOfReg = np.asscalar(writeValsPerVFAT['%s'%bName])
+                if writeValOfReg != readBackVal:
+                    print "VFAT%i: %s mismatch, write val = %i, readback = %i"%(vfat, regName, writeValOfReg, readBackVal)
+
+    return

--- a/qcutilities.py
+++ b/qcutilities.py
@@ -1,10 +1,3 @@
-from gempython.tools.vfat_user_functions_uhal import *
-
-import numpy as np
-import root_numpy as rp
-import ROOT as r
-import sys
-
 def readBackCheck(rootTree, dict_Names, device, gtx):
     """
     Given an input set of registers, and expected values of those registers, read from all VFATs on device.gtx to see if there are any differences between written and read values.
@@ -14,6 +7,13 @@ def readBackCheck(rootTree, dict_Names, device, gtx):
     device - optohybrid the vfats belong to that you want to check
     gtx - link of this optohybrid
     """
+
+    from gempython.tools.vfat_user_functions_uhal import *
+    
+    import numpy as np
+    import root_numpy as rp
+    import ROOT as r
+    import sys
     
     # Check that the requested register is supported
     list_KnownRegs = parameters.defaultValues.keys()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-numpy>=1.10.4
+#numpy>=1.10.4
+numpy>=1.7.1
 root-numpy>=4.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-#numpy>=1.10.4
-#root-numpy>=4.7.2
+numpy>=1.10.4
+root-numpy>=4.7.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implementation of: https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/122

Adds to `confChamber.py` the `--compare` option.  The following behavior occurs:

- Now by default whenever `--filename`, `--chConfig`, and/or `--vfatConfig` are supplied a readback of registers is performed and reports any differences between the values that are stored, after writing, and the values requested
- If `--compare` option is supplied with `--filename`, `--chConfig`, and/or `--vfatConfig` registers are **not** written, instead a readback is performed and any differences between values that are stored and the values requested are reported.

For `--filename` or `--chConfig` the readback is of VFAT channel registers and `trimDAC` and `mask` are checked.

For `--vfatConfig` the readback is of `VThreshold1` and `ContReg3` (e.g. `trimRange`).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Provides a cross-check of the configuration to ensure the correct register values are written.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Freshly tested here: http://cmsonline.cern.ch/cms-elog/1009166

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
