### PR TITLE
Bug Fix: ultraThreshold.py, addressing #'s 129 & 130

### DIFF
--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -159,6 +159,10 @@ try:
             stopLocalT1(ohboard, options.gtx)
             pass
         pass
+
+    # Place VFATs back in sleep mode
+    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x36, mask)
+
 except Exception as e:
     myT.AutoSave("SaveSelf")
     print "An exception occurred", e

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -92,7 +92,9 @@ try:
     writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x37, mask)
     writeAllVFATs(ohboard, options.gtx, "VThreshold2", options.vt2, mask)
 
+    trgSrc = getTriggerSource(ohboard,options.gtx)
     if options.perchannel:
+        setTriggerSource(ohboard,options.gtx,0x1)
         mode[0] = scanmode.THRESHCH
         sendL1A(ohboard, options.gtx, interval=250, number=0)
 
@@ -123,10 +125,12 @@ try:
             myT.AutoSave("SaveSelf")
             pass
 
+        setTriggerSource(ohboard,options.gtx,trgSrc)
         stopLocalT1(ohboard, options.gtx)
         pass
     else:
         if options.trkdata:
+            setTriggerSource(ohboard,options.gtx,0x1)
             mode[0] = scanmode.THRESHTRK
             sendL1A(ohboard, options.gtx, interval=250, number=0)
         else:
@@ -156,6 +160,7 @@ try:
         myT.AutoSave("SaveSelf")
 
         if options.trkdata:
+            setTriggerSource(ohboard,options.gtx,trgSrc)
             stopLocalT1(ohboard, options.gtx)
             pass
         pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addressing: https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/129 and https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/130

VFATs will not be left in run mode after a scan finishes.
The trigger source will not be undefined when running a scan.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
VFATs left in run mode at the end of a scan does not match with `ultraLatency.py` or `ultraScurve.py` and could lead to unintended consequences.

Trigger source not being defined seems to have contributed too: https://github.com/cms-gem-daq-project/cmsgemos/issues/149#issuecomment-330919427 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Taking new scans and analyzing them: http://cmsonline.cern.ch/cms-elog/1010787

This was done using `cmsgemos` tag: ab771dd9cda1e946cdc120e0a99096f312217027

So this does not have the patch mentioned here: https://github.com/cms-gem-daq-project/cmsgemos/pull/150

So I think this means the above cmgemos patch is not needed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
