### PR TITLE
Bug Fix: Remove vfatmask usage when using readAllVFATs(...)

### DIFF
--- a/fastLatency.py
+++ b/fastLatency.py
@@ -71,15 +71,15 @@ try:
     writeAllVFATs(ohboard, options.gtx, "ContReg2",    ((options.MSPL-1)<<4))
     # writeAllVFATs(ohboard, options.gtx, "VThreshold1", options.vt1)
 
-    vals  = readAllVFATs(ohboard, options.gtx, "VThreshold1", mask)
+    vals  = readAllVFATs(ohboard, options.gtx, "VThreshold1", 0x0)
     vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
                         range(0,24)))
-    vals  = readAllVFATs(ohboard, options.gtx, "VThreshold2", mask)
+    vals  = readAllVFATs(ohboard, options.gtx, "VThreshold2", 0x0)
     vt2vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
                         range(0,24)))
     vthvals =  dict(map(lambda slotID: (slotID, vt2vals[slotID]-vt2vals[slotID]),
                         range(0,24)))
-    vals = readAllVFATs(ohboard, options.gtx, "ContReg2",    mask)
+    vals = readAllVFATs(ohboard, options.gtx, "ContReg2",    0x0)
     msplvals =  dict(map(lambda slotID: (slotID, (vals[slotID]>>4)&0x7),
                          range(0,24)))
 

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -124,15 +124,15 @@ try:
     writeAllVFATs(ohboard, options.gtx, "ContReg2",    ((options.MSPL-1)<<4))
     writeAllVFATs(ohboard, options.gtx, "VThreshold2", options.vt2, mask)
 
-    vals  = readAllVFATs(ohboard, options.gtx, "VThreshold1", mask)
+    vals  = readAllVFATs(ohboard, options.gtx, "VThreshold1", 0x0)
     vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
                         range(0,24)))
-    vals  = readAllVFATs(ohboard, options.gtx, "VThreshold2", mask)
+    vals  = readAllVFATs(ohboard, options.gtx, "VThreshold2", 0x0)
     vt2vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
                         range(0,24)))
     vthvals =  dict(map(lambda slotID: (slotID, vt2vals[slotID]-vt2vals[slotID]),
                         range(0,24)))
-    vals = readAllVFATs(ohboard, options.gtx, "ContReg2",    mask)
+    vals = readAllVFATs(ohboard, options.gtx, "ContReg2",    0x0)
     msplvals =  dict(map(lambda slotID: (slotID, (1+(vals[slotID]>>4)&0x7)),
                          range(0,24)))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addressing: https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/128

Based on the discussion shown in [cmsgemos #146](https://github.com/cms-gem-daq-project/cmsgemos/issues/146) it seems like the best approach is to not use a vfatmask when using `readAllVFATs(...)` which does a broadcast read.  This will ensure that the ordering of the returned data is correct by default.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Values returned by a broadcast read when a vfatmask is used appear out of order.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change is trivial, and tests performed in [cmsgemos #146](https://github.com/cms-gem-daq-project/cmsgemos/issues/146) show the desired behavior, e.g. supplying a mask of 0x0 returns the correctly ordered data and does not crash.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->