### PR TITLE
New Feature: debug flag transferred by run_scans.py & confAllChambers.py

### DIFF
--- a/confAllChambers.py
+++ b/confAllChambers.py
@@ -3,7 +3,7 @@
 def launch(args):
   return launchArgs(*args)
 
-def launchArgs(shelf,link,slot,run,vt1,vt1bump,config,cName,ztrim):
+def launchArgs(shelf,link,slot,run,vt1,vt1bump,config,cName,ztrim,debug=False):
     import datetime,os,sys
     from subprocess import CalledProcessError
     from mapping.chamberInfo import chamber_config
@@ -13,6 +13,10 @@ def launchArgs(shelf,link,slot,run,vt1,vt1bump,config,cName,ztrim):
     filename="%s/%s/trim/z%f/config/SCurveData_Trimmed/SCurveFitData.root"%(dataPath,cName,options.ztrim)
 
     cmd = ["confChamber.py","-s%d"%(slot),"-g%d"%(link),"--shelf=%i"%(shelf)]
+
+    if debug:
+        cmd.append("--debug")
+        pass
 
     if run:
         cmd.append("--run")
@@ -76,6 +80,7 @@ if __name__ == '__main__':
                         [options.config    for x in range(len(chamber_config))],
                         [chamber_config[x] for x in chamber_config.keys()],
                         [options.ztrim     for x in range(len(chamber_config))],
+                        [options.debug     for x in range(len(chamber_config))]
                   )
             )
         pass
@@ -83,7 +88,7 @@ if __name__ == '__main__':
         print "Configuring chambers in serial mode"
         for link in chamber_config.keys():
             chamber = chamber_config[link]
-            launchArgs(options.shelf,link,options.slot,options.run,options.vt1,options.vt1bump,options.config,chamber,options.ztrim)
+            launchArgs(options.shelf,link,options.slot,options.run,options.vt1,options.vt1bump,options.config,chamber,options.ztrim,options.debug)
             pass
         pass
     else:
@@ -103,6 +108,7 @@ if __name__ == '__main__':
                                                 [options.config    for x in range(len(chamber_config))],
                                                 [chamber_config[x] for x in chamber_config.keys()],
                                                 [options.ztrim     for x in range(len(chamber_config))],
+                                                [options.debug     for x in range(len(chamber_config))]
                                                 )
                                  )
             # timeout must be properly set, otherwise tasks will crash

--- a/confChamber.py
+++ b/confChamber.py
@@ -30,7 +30,7 @@ parser.add_option("--vt1bump", type="int", dest="vt1bump",
 (options, args) = parser.parse_args()
 
 if options.debug:
-    uhal.setLogLevelTo( uhal.LogLevel.DEBUG )
+    uhal.setLogLevelTo( uhal.LogLevel.INFO )
 else:
     uhal.setLogLevelTo( uhal.LogLevel.ERROR )
 

--- a/fastLatency.py
+++ b/fastLatency.py
@@ -24,7 +24,7 @@ if options.MSPL not in range(1,9):
     exit(1)
 
 if options.debug:
-    uhal.setLogLevelTo( uhal.LogLevel.DEBUG )
+    uhal.setLogLevelTo( uhal.LogLevel.INFO )
 else:
     uhal.setLogLevelTo( uhal.LogLevel.ERROR )
 

--- a/fastLatency.py
+++ b/fastLatency.py
@@ -17,16 +17,14 @@ parser.add_option("--vt1", type="int", dest="vt1",
                   help="VThreshold1 DAC value for all VFATs", metavar="vt1", default=100)
 
 parser.set_defaults(nevts=1000)
-
 (options, args) = parser.parse_args()
-uhal.setLogLevelTo( uhal.LogLevel.WARNING )
 
 if options.MSPL not in range(1,9):
     print "Invalid MSPL specified: %d, must be in range [1,8]"%(options.MSPL)
     exit(1)
 
 if options.debug:
-    uhal.setLogLevelTo( uhal.LogLevel.INFO )
+    uhal.setLogLevelTo( uhal.LogLevel.DEBUG )
 else:
     uhal.setLogLevelTo( uhal.LogLevel.ERROR )
 
@@ -58,18 +56,15 @@ utime[0] = int(time.time())
 
 ohboard      = getOHObject(options.slot,options.gtx,options.shelf,options.debug)
 seenTriggers = 0
-mask         = 0
 
 try:
     print "Setting trigger source"
-    # setTriggerSource(ohboard,options.gtx,0x0) # GTX
     setTriggerSource(ohboard,options.gtx,0x5) # GBT
 
     print "Setting run mode"
     writeAllVFATs(ohboard, options.gtx, "ContReg0",   0x37)
     print "Setting MSPL to %d"%(options.MSPL)
     writeAllVFATs(ohboard, options.gtx, "ContReg2",    ((options.MSPL-1)<<4))
-    # writeAllVFATs(ohboard, options.gtx, "VThreshold1", options.vt1)
 
     vals  = readAllVFATs(ohboard, options.gtx, "VThreshold1", 0x0)
     vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
@@ -127,4 +122,3 @@ finally:
     myF.cd()
     myT.Write()
     myF.Close()
-

--- a/run_scans.py
+++ b/run_scans.py
@@ -6,7 +6,7 @@ def launchTests(args):
 def launchTestsArgs(tool, shelf, slot, link, chamber, vfatmask, scanmin, scanmax, nevts, stepSize=1,
                     vt1=None,vt2=0,mspl=None,perchannel=False,trkdata=False,ztrim=4.0,
                     config=False,amc13local=False,t3trig=False, randoms=0, throttle=0,
-                    internal=False):
+                    internal=False, debug=False):
   import datetime,os,sys
   import subprocess
   from subprocess import CalledProcessError
@@ -23,6 +23,8 @@ def launchTestsArgs(tool, shelf, slot, link, chamber, vfatmask, scanmin, scanmax
   setupCmds = []
   preCmd = None
   cmd = ["%s"%(tool),"-s%i"%(slot),"-g%i"%(link),"--shelf=%i"%(shelf), "--nevts=%i"%(nevts), "--vfatmask=0x%x"%(vfatmask)]
+  if debug:
+    cmd.append( "--debug")
   if tool == "ultraScurve.py":
     scanType = "scurve"
     dataType = "SCurve"
@@ -212,6 +214,7 @@ if __name__ == '__main__':
                          [options.randoms for x in range(len(chamber_config))],
                          [options.throttle for x in range(len(chamber_config))],
                          [options.internal for x in range(len(chamber_config))],
+                         [options.debug for x in range(len(chamber_config))]
                          )
             )
   if options.series:
@@ -240,7 +243,8 @@ if __name__ == '__main__':
                     options.t3trig,
                     options.randoms,
                     options.throttle,
-                    options.internal
+                    options.internal,
+                    options.debug
                   ])
       pass
     pass
@@ -275,6 +279,7 @@ if __name__ == '__main__':
                                           [options.randoms for x in range(len(chamber_config))],
                                           [options.throttle for x in range(len(chamber_config))],
                                           [options.internal for x in range(len(chamber_config))],
+                                          [options.debug for x in range(len(chamber_config))]
                                           )
                            )
       # timeout must be properly set, otherwise tasks will crash

--- a/trimChamber.py
+++ b/trimChamber.py
@@ -80,7 +80,7 @@ for vfat in range(0,24):
 for vfat in range(0,24):
     writeVFAT(ohboard, options.gtx, vfat, "ContReg3", tRanges[vfat], options.debug)
 
-zeroAllVFATChannels(ohboard,options.gtx,mask=0x0,options.debug)
+zeroAllVFATChannels(ohboard,options.gtx,mask=0x0,debug=options.debug)
 
 # Scurve scan with trimdac set to 0
 filename0 = "%s/SCurveData_trimdac0_range0.root"%dirPath

--- a/trimChamber.py
+++ b/trimChamber.py
@@ -23,7 +23,7 @@ parser.add_option("--vt1", type="int", dest="vt1",
 (options, args) = parser.parse_args()
 
 if options.debug:
-    uhal.setLogLevelTo( uhal.LogLevel.DEBUG )
+    uhal.setLogLevelTo( uhal.LogLevel.INFO )
 else:
     uhal.setLogLevelTo( uhal.LogLevel.ERROR )
 

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -114,10 +114,12 @@ LATENCY_MAX = options.scanmax
 
 N_EVENTS = Nev[0]
 
+mask = options.vfatmask
+
 try:
-    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x37, options.vfatmask)
+    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x37, mask)
     writeAllVFATs(ohboard, options.gtx, "ContReg2",    ((options.MSPL-1)<<4))
-    writeAllVFATs(ohboard, options.gtx, "VThreshold2", options.vt2, options.vfatmask)
+    writeAllVFATs(ohboard, options.gtx, "VThreshold2", options.vt2, mask)
 
     vals  = readAllVFATs(ohboard, options.gtx, "VThreshold1", 0x0)
     vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
@@ -151,7 +153,7 @@ try:
     print "AMC13: %s"%(amc13nL1A)
     print "AMC: %s"%(amcnL1A)
     print "OH%s: %s"%(options.gtx,ohnL1A)
-    oh.configureScanModule(ohboard, options.gtx, mode, options.vfatmask,
+    oh.configureScanModule(ohboard, options.gtx, mode, mask,
                         scanmin=LATENCY_MIN, scanmax=LATENCY_MAX,
                         stepsize=step,
                         numtrigs=int(options.nevts),
@@ -165,8 +167,8 @@ try:
         oh.setTriggerSource(ohboard,options.gtx,0x1)
         oh.sendL1ACalPulse(ohboard, options.gtx, delay=20, interval=400, number=0)
         chanReg = ((1&0x1) << 6)|((0&0x1) << 5)|(0&0x1f)
-        writeAllVFATs(ohboard, options.gtx, "VFATChannels.ChanReg0", chanReg, options.vfatmask)
-        writeAllVFATs(ohboard, options.gtx, "VCal",     250, options.vfatmask)
+        writeAllVFATs(ohboard, options.gtx, "VFATChannels.ChanReg0", chanReg, mask)
+        writeAllVFATs(ohboard, options.gtx, "VCal",     250, mask)
     else:
         if options.amc13local:
             amc.enableL1A(amcboard)
@@ -247,7 +249,7 @@ try:
             pass
         pass
     myT.AutoSave("SaveSelf")
-    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x36, options.vfatmask)
+    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x36, mask)
     if options.internal:
         oh.stopLocalT1(ohboard, options.gtx)
         pass

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -33,13 +33,10 @@ parser.add_option("--t3trig", action="store_true", dest="t3trig",
                   help="Set up for using AMC13 T3 trigger input", metavar="t3trig")
 parser.add_option("--throttle", type="int", default=0, dest="throttle",
                   help="factor by which to throttle the input L1A rate, e.g. new trig rate = L1A rate / throttle", metavar="throttle")
-parser.add_option("--vt1", type="int", dest="vt1",
-                  help="VThreshold1 DAC value for all VFATs", metavar="vt1", default=100)
 parser.add_option("--vt2", type="int", dest="vt2", default=0,
                   help="Specify VT2 to use", metavar="vt2")
 
 parser.set_defaults(scanmin=153,scanmax=172,nevts=500)
-
 (options, args) = parser.parse_args()
 
 if options.scanmin not in range(256) or options.scanmax not in range(256) or not (options.scanmax > options.scanmin):
@@ -64,7 +61,7 @@ if (step + options.scanmin > options.scanmax):
     step = options.scanmax - options.scanmin
 
 if options.debug:
-    uhal.setLogLevelTo(uhal.LogLevel.INFO)
+    uhal.setLogLevelTo(uhal.LogLevel.DEBUG)
 else:
     uhal.setLogLevelTo(uhal.LogLevel.ERROR)
 
@@ -117,12 +114,10 @@ LATENCY_MAX = options.scanmax
 
 N_EVENTS = Nev[0]
 
-mask = options.vfatmask
-
 try:
-    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x37, mask)
+    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x37, options.vfatmask)
     writeAllVFATs(ohboard, options.gtx, "ContReg2",    ((options.MSPL-1)<<4))
-    writeAllVFATs(ohboard, options.gtx, "VThreshold2", options.vt2, mask)
+    writeAllVFATs(ohboard, options.gtx, "VThreshold2", options.vt2, options.vfatmask)
 
     vals  = readAllVFATs(ohboard, options.gtx, "VThreshold1", 0x0)
     vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
@@ -156,7 +151,7 @@ try:
     print "AMC13: %s"%(amc13nL1A)
     print "AMC: %s"%(amcnL1A)
     print "OH%s: %s"%(options.gtx,ohnL1A)
-    oh.configureScanModule(ohboard, options.gtx, mode, mask,
+    oh.configureScanModule(ohboard, options.gtx, mode, options.vfatmask,
                         scanmin=LATENCY_MIN, scanmax=LATENCY_MAX,
                         stepsize=step,
                         numtrigs=int(options.nevts),
@@ -165,14 +160,13 @@ try:
     sys.stdout.flush()
     amc13board.enableLocalL1A(True)
 
-
     if options.internal:
         amc.blockL1A(amcboard)
         oh.setTriggerSource(ohboard,options.gtx,0x1)
         oh.sendL1ACalPulse(ohboard, options.gtx, delay=20, interval=400, number=0)
         chanReg = ((1&0x1) << 6)|((0&0x1) << 5)|(0&0x1f)
-        writeAllVFATs(ohboard, options.gtx, "VFATChannels.ChanReg0", chanReg, mask)
-        writeAllVFATs(ohboard, options.gtx, "VCal",     250, mask)
+        writeAllVFATs(ohboard, options.gtx, "VFATChannels.ChanReg0", chanReg, options.vfatmask)
+        writeAllVFATs(ohboard, options.gtx, "VCal",     250, options.vfatmask)
     else:
         if options.amc13local:
             amc.enableL1A(amcboard)
@@ -253,7 +247,7 @@ try:
             pass
         pass
     myT.AutoSave("SaveSelf")
-    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x36, mask)
+    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x36, options.vfatmask)
     if options.internal:
         oh.stopLocalT1(ohboard, options.gtx)
         pass

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -61,7 +61,7 @@ if (step + options.scanmin > options.scanmax):
     step = options.scanmax - options.scanmin
 
 if options.debug:
-    uhal.setLogLevelTo(uhal.LogLevel.DEBUG)
+    uhal.setLogLevelTo(uhal.LogLevel.INFO)
 else:
     uhal.setLogLevelTo(uhal.LogLevel.ERROR)
 

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -41,7 +41,7 @@ if not (0 <= options.chMin <= options.chMax < 128):
     pass
 
 if options.debug:
-    uhal.setLogLevelTo( uhal.LogLevel.DEBUG )
+    uhal.setLogLevelTo( uhal.LogLevel.INFO )
 else:
     uhal.setLogLevelTo( uhal.LogLevel.ERROR )
 

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -120,8 +120,6 @@ if options.debug:
     CHAN_MAX = 5
     pass
 
-mask = options.vfatmask
-
 try:
     setTriggerSource(ohboard,options.gtx,1)
     configureLocalT1(ohboard, options.gtx, 1, 0, options.pDel, options.L1Atime, 0, options.debug)
@@ -129,16 +127,13 @@ try:
 
     print 'Link %i T1 controller status: %i'%(options.gtx,getLocalT1Status(ohboard,options.gtx))
 
-    #biasAllVFATs(ohboard,options.gtx,0x0,enable=False)
-    #writeAllVFATs(ohboard, options.gtx, "VThreshold1", 100, 0)
-
-    writeAllVFATs(ohboard, options.gtx, "Latency",    options.latency, mask)
-    writeAllVFATs(ohboard, options.gtx, "ContReg0", 0x37, mask)
-    writeAllVFATs(ohboard, options.gtx, "ContReg2",   (options.MSPL - 1) << 4, mask)
-    writeAllVFATs(ohboard, options.gtx, "CalPhase",  0xff >> (8 - options.CalPhase), mask)
+    writeAllVFATs(ohboard, options.gtx, "Latency",    options.latency, options.vfatmask)
+    writeAllVFATs(ohboard, options.gtx, "ContReg0", 0x37, options.vfatmask)
+    writeAllVFATs(ohboard, options.gtx, "ContReg2",   (options.MSPL - 1) << 4, options.vfatmask)
+    writeAllVFATs(ohboard, options.gtx, "CalPhase",  0xff >> (8 - options.CalPhase), options.vfatmask)
 
     for vfat in range(0,24):
-        if (mask >> vfat) & 0x1: continue
+        if (options.vfatmask >> vfat) & 0x1: continue
         for scCH in range(CHAN_MIN,CHAN_MAX):
             trimVal = (0x3f & readVFAT(ohboard,options.gtx,vfat,"VFATChannels.ChanReg%d"%(scCH)))
             writeVFAT(ohboard,options.gtx,vfat,"VFATChannels.ChanReg%d"%(scCH),trimVal)
@@ -147,17 +142,17 @@ try:
         vfatCH[0] = scCH
         print "Channel #"+str(scCH)
         for vfat in range(0,24):
-            if (mask >> vfat) & 0x1: continue
+            if (options.vfatmask >> vfat) & 0x1: continue
             trimVal = (0x3f & readVFAT(ohboard,options.gtx,vfat,"VFATChannels.ChanReg%d"%(scCH)))
             writeVFAT(ohboard,options.gtx,vfat,"VFATChannels.ChanReg%d"%(scCH),trimVal+64)
-        configureScanModule(ohboard, options.gtx, scanmode.SCURVE, mask, channel = scCH,
+        configureScanModule(ohboard, options.gtx, scanmode.SCURVE, options.vfatmask, channel = scCH,
                             scanmin = SCURVE_MIN, scanmax = SCURVE_MAX, numtrigs = int(N_EVENTS),
                             useUltra = True, debug = options.debug)
         printScanConfiguration(ohboard, options.gtx, useUltra = True, debug = options.debug)
         startScanModule(ohboard, options.gtx, useUltra = True, debug = options.debug)
         scanData = getUltraScanResults(ohboard, options.gtx, SCURVE_MAX - SCURVE_MIN + 1, options.debug)
         for i in range(0,24):
-            if (mask >> i) & 0x1: continue
+            if (options.vfatmask >> i) & 0x1: continue
             vfatN[0] = i
             dataNow = scanData[i]
             trimRange[0] = (0x07 & readVFAT(ohboard,options.gtx, i,"ContReg3"))
@@ -175,14 +170,14 @@ try:
                 finally:
                     myT.Fill()
         for vfat in range(0,24):
-            if (mask >> vfat) & 0x1: continue
+            if (options.vfatmask >> vfat) & 0x1: continue
             trimVal = (0x3f & readVFAT(ohboard,options.gtx,vfat,"VFATChannels.ChanReg%d"%(scCH)))
             writeVFAT(ohboard,options.gtx,vfat,"VFATChannels.ChanReg%d"%(scCH),trimVal)
         myT.AutoSave("SaveSelf")
         sys.stdout.flush()
         pass
     stopLocalT1(ohboard, options.gtx)
-    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x36, mask)
+    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x36, options.vfatmask)
 
 except Exception as e:
     myT.AutoSave("SaveSelf")
@@ -191,7 +186,3 @@ finally:
     myF.cd()
     myT.Write()
     myF.Close()
-
-
-
-

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -32,7 +32,7 @@ if options.vt2 not in range(256):
     exit(1)
 
 if options.debug:
-    uhal.setLogLevelTo( uhal.LogLevel.DEBUG )
+    uhal.setLogLevelTo( uhal.LogLevel.INFO )
 else:
     uhal.setLogLevelTo( uhal.LogLevel.ERROR )
 

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -85,12 +85,10 @@ if options.debug:
     CHAN_MAX = 5
     pass
 
-mask = options.vfatmask
-
 try:
-    writeAllVFATs(ohboard, options.gtx, "Latency",     0, mask)
-    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x37, mask)
-    writeAllVFATs(ohboard, options.gtx, "VThreshold2", options.vt2, mask)
+    writeAllVFATs(ohboard, options.gtx, "Latency",     0, options.vfatmask)
+    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x37, options.vfatmask)
+    writeAllVFATs(ohboard, options.gtx, "VThreshold2", options.vt2, options.vfatmask)
 
     trgSrc = getTriggerSource(ohboard,options.gtx)
     if options.perchannel:
@@ -101,7 +99,7 @@ try:
         for scCH in range(CHAN_MIN,CHAN_MAX):
             vfatCH[0] = scCH
             print "Channel #"+str(scCH)
-            configureScanModule(ohboard, options.gtx, mode[0], mask, channel=scCH,
+            configureScanModule(ohboard, options.gtx, mode[0], options.vfatmask, channel=scCH,
                                 scanmin=THRESH_MIN, scanmax=THRESH_MAX,
                                 numtrigs=int(N_EVENTS),
                                 useUltra=True, debug=options.debug)
@@ -111,7 +109,7 @@ try:
             scanData = getUltraScanResults(ohboard, options.gtx, THRESH_MAX - THRESH_MIN + 1, options.debug)
             sys.stdout.flush()
             for i in range(0,24):
-            	if (mask >> i) & 0x1: continue
+            	if (options.vfatmask >> i) & 0x1: continue
                 vfatN[0] = i
                 dataNow      = scanData[i]
                 trimRange[0] = (0x07 & readVFAT(ohboard,options.gtx, i,"ContReg3"))
@@ -136,7 +134,7 @@ try:
         else:
             mode[0] = scanmode.THRESHTRG
             pass
-        configureScanModule(ohboard, options.gtx, mode[0], mask,
+        configureScanModule(ohboard, options.gtx, mode[0], options.vfatmask,
                             scanmin=THRESH_MIN, scanmax=THRESH_MAX,
                             numtrigs=int(N_EVENTS),
                             useUltra=True, debug=options.debug)
@@ -146,7 +144,7 @@ try:
         scanData = getUltraScanResults(ohboard, options.gtx, THRESH_MAX - THRESH_MIN + 1, options.debug)
         sys.stdout.flush()
         for i in range(0,24):
-            if (mask >> i) & 0x1: continue
+            if (options.vfatmask >> i) & 0x1: continue
             vfatN[0] = i
             dataNow      = scanData[i]
             trimRange[0] = (0x07 & readVFAT(ohboard,options.gtx, i,"ContReg3"))
@@ -166,7 +164,7 @@ try:
         pass
 
     # Place VFATs back in sleep mode
-    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x36, mask)
+    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x36, options.vfatmask)
 
 except Exception as e:
     myT.AutoSave("SaveSelf")

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -85,10 +85,12 @@ if options.debug:
     CHAN_MAX = 5
     pass
 
+mask = options.vfatmask
+
 try:
-    writeAllVFATs(ohboard, options.gtx, "Latency",     0, options.vfatmask)
-    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x37, options.vfatmask)
-    writeAllVFATs(ohboard, options.gtx, "VThreshold2", options.vt2, options.vfatmask)
+    writeAllVFATs(ohboard, options.gtx, "Latency",     0, mask)
+    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x37, mask)
+    writeAllVFATs(ohboard, options.gtx, "VThreshold2", options.vt2, mask)
 
     trgSrc = getTriggerSource(ohboard,options.gtx)
     if options.perchannel:
@@ -99,7 +101,7 @@ try:
         for scCH in range(CHAN_MIN,CHAN_MAX):
             vfatCH[0] = scCH
             print "Channel #"+str(scCH)
-            configureScanModule(ohboard, options.gtx, mode[0], options.vfatmask, channel=scCH,
+            configureScanModule(ohboard, options.gtx, mode[0], mask, channel=scCH,
                                 scanmin=THRESH_MIN, scanmax=THRESH_MAX,
                                 numtrigs=int(N_EVENTS),
                                 useUltra=True, debug=options.debug)
@@ -109,7 +111,7 @@ try:
             scanData = getUltraScanResults(ohboard, options.gtx, THRESH_MAX - THRESH_MIN + 1, options.debug)
             sys.stdout.flush()
             for i in range(0,24):
-            	if (options.vfatmask >> i) & 0x1: continue
+            	if (mask >> i) & 0x1: continue
                 vfatN[0] = i
                 dataNow      = scanData[i]
                 trimRange[0] = (0x07 & readVFAT(ohboard,options.gtx, i,"ContReg3"))
@@ -134,7 +136,7 @@ try:
         else:
             mode[0] = scanmode.THRESHTRG
             pass
-        configureScanModule(ohboard, options.gtx, mode[0], options.vfatmask,
+        configureScanModule(ohboard, options.gtx, mode[0], mask,
                             scanmin=THRESH_MIN, scanmax=THRESH_MAX,
                             numtrigs=int(N_EVENTS),
                             useUltra=True, debug=options.debug)
@@ -144,7 +146,7 @@ try:
         scanData = getUltraScanResults(ohboard, options.gtx, THRESH_MAX - THRESH_MIN + 1, options.debug)
         sys.stdout.flush()
         for i in range(0,24):
-            if (options.vfatmask >> i) & 0x1: continue
+            if (mask >> i) & 0x1: continue
             vfatN[0] = i
             dataNow      = scanData[i]
             trimRange[0] = (0x07 & readVFAT(ohboard,options.gtx, i,"ContReg3"))
@@ -164,7 +166,7 @@ try:
         pass
 
     # Place VFATs back in sleep mode
-    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x36, options.vfatmask)
+    writeAllVFATs(ohboard, options.gtx, "ContReg0",    0x36, mask)
 
 except Exception as e:
     myT.AutoSave("SaveSelf")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `--debug` flag was not being transferred by `run_scans.py` or `confAllChambers.py` to the relevant tool.  Additionally the `--debug` flag within tools was not applied uniformly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Trying to troubleshoot hardware problems requires appropriate debugging info

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
http://cmsonline.cern.ch/cms-elog/1013587

Relevant log files and outputs can be found at:
```
/tmp/GE11-X-S-CERN-0001/
```

On the `cosmicstandtif` machine.
### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
