### PR TITLE
New Feature: ChipID added to TTree, readBackCheck now checks ChipID & vt1bump 

### DIFF
--- a/confChamber.py
+++ b/confChamber.py
@@ -68,7 +68,7 @@ if options.filename:
     try:
         inF = r.TFile(options.filename)
         chTree = inF.Get("scurveFitTree")
-        dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg", "vfatID:ChipID1" }
+        dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg", "vfatID":"ChipID1" }
 
         if not options.compare:
             print 'Configuring Channel Registers based on %s'%options.filename
@@ -88,7 +88,7 @@ if options.chConfig:
     try:
         chTree = r.TTree('chTree','Tree holding Channel Configuration Parameters')
         chTree.ReadFile(options.chConfig)
-        dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg", "vfatID:ChipID1" }
+        dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg", "vfatID":"ChipID1" }
 
         if not options.compare:
             print 'Configuring Channel Registers based on %s'%options.chConfig
@@ -107,7 +107,7 @@ if options.vfatConfig:
     try:
         vfatTree = r.TTree('vfatTree','Tree holding VFAT Configuration Parameters')
         vfatTree.ReadFile(options.vfatConfig)
-        dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3", "vfatID:ChipID1" }
+        dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3", "vfatID":"ChipID1" }
 
         if not options.compare:
             print 'Configuring VFAT Registers based on %s'%options.vfatConfig

--- a/confChamber.py
+++ b/confChamber.py
@@ -68,7 +68,7 @@ if options.filename:
     try:
         inF = r.TFile(options.filename)
         chTree = inF.Get("scurveFitTree")
-        dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg" }
+        dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg", "vfatID:ChipID1" }
 
         if not options.compare:
             print 'Configuring Channel Registers based on %s'%options.filename
@@ -88,7 +88,7 @@ if options.chConfig:
     try:
         chTree = r.TTree('chTree','Tree holding Channel Configuration Parameters')
         chTree.ReadFile(options.chConfig)
-        dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg" }
+        dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg", "vfatID:ChipID1" }
 
         if not options.compare:
             print 'Configuring Channel Registers based on %s'%options.chConfig
@@ -107,7 +107,7 @@ if options.vfatConfig:
     try:
         vfatTree = r.TTree('vfatTree','Tree holding VFAT Configuration Parameters')
         vfatTree.ReadFile(options.vfatConfig)
-        dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3" }
+        dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3", "vfatID:ChipID1" }
 
         if not options.compare:
             print 'Configuring VFAT Registers based on %s'%options.vfatConfig
@@ -118,9 +118,9 @@ if options.vfatConfig:
                 writeVFAT(ohboard, options.gtx, int(event.vfatN), "ContReg3", int(event.trimRange),0)
         
         print 'Comparing Curently Stored VFAT Registers with %s'%options.vfatConfig
-        if options.vt1bump != 0:
-            print "Mismatches between write & readback valus for VThreshold1 should be exactly %i" %(options.vt1bump)
-        readBackCheck(vfatTree, dict_readBack, ohboard, options.gtx)
+        #if options.vt1bump != 0:
+        #    print "Mismatches between write & readback valus for VThreshold1 should be exactly %i" %(options.vt1bump)
+        readBackCheck(vfatTree, dict_readBack, ohboard, options.gtx, options.vt1bump)
 
     except Exception as e:
         print '%s does not seem to exist'%options.filename

--- a/confChamber.py
+++ b/confChamber.py
@@ -68,7 +68,7 @@ if options.filename:
     try:
         inF = r.TFile(options.filename)
         chTree = inF.Get("scurveFitTree")
-        dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg", "vfatID":"ChipID1" }
+        dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg", "vfatID":"ChipID" }
 
         if not options.compare:
             print 'Configuring Channel Registers based on %s'%options.filename
@@ -88,7 +88,7 @@ if options.chConfig:
     try:
         chTree = r.TTree('chTree','Tree holding Channel Configuration Parameters')
         chTree.ReadFile(options.chConfig)
-        dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg", "vfatID":"ChipID1" }
+        dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg", "vfatID":"ChipID" }
 
         if not options.compare:
             print 'Configuring Channel Registers based on %s'%options.chConfig
@@ -107,7 +107,7 @@ if options.vfatConfig:
     try:
         vfatTree = r.TTree('vfatTree','Tree holding VFAT Configuration Parameters')
         vfatTree.ReadFile(options.vfatConfig)
-        dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3", "vfatID":"ChipID1" }
+        dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3", "vfatID":"ChipID" }
 
         if not options.compare:
             print 'Configuring VFAT Registers based on %s'%options.vfatConfig

--- a/fastLatency.py
+++ b/fastLatency.py
@@ -37,6 +37,8 @@ Dly = array( 'i', [ -1 ] )
 myT.Branch( 'Dly', Dly, 'Dly/I' )
 vfatN = array( 'i', [ -1 ] )
 myT.Branch( 'vfatN', vfatN, 'vfatN/I' )
+vfatID = array( 'i', [-1] )
+myT.Branch( 'vfatID', vfatID, 'vfatID/I' ) #Hex Chip ID of VFAT
 vth = array( 'i', [ 0 ] )
 myT.Branch( 'vth', vth, 'vth/I' )
 vth1 = array( 'i', [ 0 ] )
@@ -96,6 +98,7 @@ try:
                     pass
                 Dly[0]   = dlyValue
                 vfatN[0] = vfat
+                vfatID[0] = getChipID(ohboard, options.gtx, vfat, options.debug)
                 mspl[0]  = msplvals[vfat]
                 vth1[0]  = vt1vals[vfat]
                 vth2[0]  = vt2vals[vfat]

--- a/fastLatency.py
+++ b/fastLatency.py
@@ -28,9 +28,10 @@ if options.debug:
 else:
     uhal.setLogLevelTo( uhal.LogLevel.ERROR )
 
-from gempython.utils.wrappers import runCommand
-cmd = ["amc_info_uhal.py","--shelf=%i"%options.shelf,"-s%i"%options.slot,"--short"]
-runCommand(cmd)
+from gempython.tools.amc_user_functions_uhal import *
+amcBoard = getAMCObject(options.slot, options.shelf, options.debug)
+printSystemSCAInfo(amcBoard, options.debug)
+printSystemTTCInfo(amcBoard, options.debug)
 
 from ROOT import TFile,TTree
 filename = options.filename

--- a/fastLatency.py
+++ b/fastLatency.py
@@ -28,6 +28,10 @@ if options.debug:
 else:
     uhal.setLogLevelTo( uhal.LogLevel.ERROR )
 
+from gempython.utils.wrappers import runCommand
+cmd = ["amc_info_uhal.py","--shelf=%i"%options.shelf,"-s%i"%options.slot,"--short"]
+runCommand(cmd)
+
 from ROOT import TFile,TTree
 filename = options.filename
 myF = TFile(filename,'recreate')

--- a/qcutilities.py
+++ b/qcutilities.py
@@ -1,4 +1,4 @@
-def readBackCheck(rootTree, dict_Names, device, gtx):
+def readBackCheck(rootTree, dict_Names, device, gtx, vt1bump=0):
     """
     Given an input set of registers, and expected values of those registers, read from all VFATs on device.gtx to see if there are any differences between written and read values.
 
@@ -72,6 +72,8 @@ def readBackCheck(rootTree, dict_Names, device, gtx):
             for vfat,readBackVal in enumerate(regMap):
                 writeValsPerVFAT = array_writeVals[ array_writeVals['vfatN'] == vfat]
                 writeValOfReg = np.asscalar(writeValsPerVFAT['%s'%bName])
+                if regName == "VThreshold1":
+                    writeValOfReg+=vt1bump
                 if writeValOfReg != readBackVal:
                     print "VFAT%i: %s mismatch, write val = %i, readback = %i"%(vfat, regName, writeValOfReg, readBackVal)
 

--- a/qcutilities.py
+++ b/qcutilities.py
@@ -64,7 +64,7 @@ def readBackCheck(rootTree, dict_Names, device, gtx):
                 valsPerVFAT = array_writeVals[ array_writeVals['vfatN'] == vfat]
                 valOfReg = np.asscalar(writeValsPerVFAT['%s'%bName])
                 if valOfReg != regValues[vfat]:
-                    print "VFAT%i: %s mismatch, expected = %i, readback = %i"%(vfat, regName, valOfReg, regValues[vfat])
+                    print "VFAT%i: %s mismatch, expected = %i, readback = %i"%(vfat, regName, hex(valOfReg), hex(regValues[vfat]))
         else: #VFAT Register, use 0xff
             regValues = readAllVFATs(device, gtx, regName, 0x0)
             regMap = map(lambda chip: chip&0xff, regValues)

--- a/qcutilities.py
+++ b/qcutilities.py
@@ -59,12 +59,11 @@ def readBackCheck(rootTree, dict_Names, device, gtx, vt1bump=0):
                             print "VFAT%i Chan%i: %s mismatch, write val = %i, readback = %i"%(vfat, chan, bName, writeValOfReg, readBackVal&0x1f)
         elif regName == "ChipID1": #ChipID
             regValues = getAllChipIDs(device, gtx, 0x0) # dict of { vfatN:chipID }
-            
             for vfat in regValues:
                 valsPerVFAT = array_writeVals[ array_writeVals['vfatN'] == vfat]
-                valOfReg = np.asscalar(writeValsPerVFAT['%s'%bName])
+                valOfReg = np.asscalar(np.unique(valsPerVFAT['%s'%bName]))
                 if valOfReg != regValues[vfat]:
-                    print "VFAT%i: %s mismatch, expected = %i, readback = %i"%(vfat, regName, hex(valOfReg), hex(regValues[vfat]))
+                    print "VFAT%i: %s mismatch, expected = %s, readback = %s"%(vfat, regName, hex(valOfReg), hex(regValues[vfat]))
         else: #VFAT Register, use 0xff
             regValues = readAllVFATs(device, gtx, regName, 0x0)
             regMap = map(lambda chip: chip&0xff, regValues)

--- a/qcutilities.py
+++ b/qcutilities.py
@@ -19,7 +19,7 @@ def readBackCheck(rootTree, dict_Names, device, gtx, vt1bump=0):
     list_KnownRegs = parameters.defaultValues.keys()
     list_KnownRegs.append("VThreshold1")
     list_KnownRegs.append("VFATChannels.ChanReg")
-    list_KnownRegs.append("ChipID1")
+    list_KnownRegs.append("ChipID")
     for regName in dict_Names.values():
         if regName not in list_KnownRegs:
             print "readBackCheck() does not understand %s"%(regName)
@@ -57,7 +57,7 @@ def readBackCheck(rootTree, dict_Names, device, gtx, vt1bump=0):
                     else:
                         if writeValOfReg != (readBackVal&0x1f):
                             print "VFAT%i Chan%i: %s mismatch, write val = %i, readback = %i"%(vfat, chan, bName, writeValOfReg, readBackVal&0x1f)
-        elif regName == "ChipID1": #ChipID
+        elif regName == "ChipID": #ChipID
             regValues = getAllChipIDs(device, gtx, 0x0) # dict of { vfatN:chipID }
             for vfat in regValues:
                 valsPerVFAT = array_writeVals[ array_writeVals['vfatN'] == vfat]

--- a/qcutilities.py
+++ b/qcutilities.py
@@ -19,6 +19,7 @@ def readBackCheck(rootTree, dict_Names, device, gtx):
     list_KnownRegs = parameters.defaultValues.keys()
     list_KnownRegs.append("VThreshold1")
     list_KnownRegs.append("VFATChannels.ChanReg")
+    list_KnownRegs.append("ChipID1")
     for regName in dict_Names.values():
         if regName not in list_KnownRegs:
             print "readBackCheck() does not understand %s"%(regName)
@@ -28,6 +29,7 @@ def readBackCheck(rootTree, dict_Names, device, gtx):
     # Get data from tree
     list_bNames = dict_Names.keys()
     list_bNames.append('vfatN')
+    #list_bNames.append('vfatID')
     if "trimDAC" in dict_Names.keys() or "mask" in dict_Names.keys():
         list_bNames.append('vfatCH')
     array_writeVals = rp.tree2array(tree=rootTree, branches=list_bNames)
@@ -55,6 +57,14 @@ def readBackCheck(rootTree, dict_Names, device, gtx):
                     else:
                         if writeValOfReg != (readBackVal&0x1f):
                             print "VFAT%i Chan%i: %s mismatch, write val = %i, readback = %i"%(vfat, chan, bName, writeValOfReg, readBackVal&0x1f)
+        elif regName == "ChipID1": #ChipID
+            regValues = getAllChipIDs(device, gtx, 0x0) # dict of { vfatN:chipID }
+            
+            for vfat in regValues:
+                valsPerVFAT = array_writeVals[ array_writeVals['vfatN'] == vfat]
+                valOfReg = np.asscalar(writeValsPerVFAT['%s'%bName])
+                if valOfReg != regValues[vfat]:
+                    print "VFAT%i: %s mismatch, expected = %i, readback = %i"%(vfat, regName, valOfReg, regValues[vfat])
         else: #VFAT Register, use 0xff
             regValues = readAllVFATs(device, gtx, regName, 0x0)
             regMap = map(lambda chip: chip&0xff, regValues)

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -65,6 +65,10 @@ if options.debug:
 else:
     uhal.setLogLevelTo(uhal.LogLevel.ERROR)
 
+from gempython.utils.wrappers import runCommand
+cmd = ["amc_info_uhal.py","--shelf=%i"%options.shelf,"-s%i"%options.slot,"--short"]
+runCommand(cmd)
+
 from ROOT import TFile,TTree
 filename = options.filename
 myF = TFile(filename,'recreate')

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -232,7 +232,7 @@ try:
     sys.stdout.flush()
     for i in range(0,24):
         vfatN[0] = i
-        vfatID[0] = getChipID(ohboard, options.gtx, vfat, options.debug)
+        vfatID[0] = getChipID(ohboard, options.gtx, i, options.debug)
         dataNow = scanData[i]
         mspl[0]  = msplvals[vfatN[0]]
         vth1[0]  = vt1vals[vfatN[0]]

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -65,10 +65,6 @@ if options.debug:
 else:
     uhal.setLogLevelTo(uhal.LogLevel.ERROR)
 
-from gempython.utils.wrappers import runCommand
-cmd = ["amc_info_uhal.py","--shelf=%i"%options.shelf,"-s%i"%options.slot,"--short"]
-runCommand(cmd)
-
 from ROOT import TFile,TTree
 filename = options.filename
 myF = TFile(filename,'recreate')
@@ -111,6 +107,9 @@ amc13base  = "gem.shelf%02d.amc13"%(options.shelf)
 amc13board = amc13.AMC13(connection_file,"%s.T1"%(amc13base),"%s.T2"%(amc13base))
 
 amcboard = amc.getAMCObject(options.slot,options.shelf,options.debug)
+amc.printSystemSCAInfo(amcboard, options.debug)
+amc.printSystemTTCInfo(amcboard, options.debug)
+
 ohboard  = oh.getOHObject(options.slot,options.gtx,options.shelf,options.debug)
 
 LATENCY_MIN = options.scanmin

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -85,6 +85,8 @@ Nhits = array( 'i', [ 0 ] )
 myT.Branch( 'Nhits', Nhits, 'Nhits/I' )
 vfatN = array( 'i', [ 0 ] )
 myT.Branch( 'vfatN', vfatN, 'vfatN/I' )
+vfatID = array( 'i', [-1] )
+myT.Branch( 'vfatID', vfatID, 'vfatID/I' ) #Hex Chip ID of VFAT
 mspl = array( 'i', [ -1 ] )
 myT.Branch( 'mspl', mspl, 'mspl/I' )
 vfatCH = array( 'i', [ 0 ] )
@@ -230,6 +232,7 @@ try:
     sys.stdout.flush()
     for i in range(0,24):
         vfatN[0] = i
+        vfatID[0] = getChipID(ohboard, options.gtx, vfat, options.debug)
         dataNow = scanData[i]
         mspl[0]  = msplvals[vfatN[0]]
         vth1[0]  = vt1vals[vfatN[0]]

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -45,10 +45,6 @@ if options.debug:
 else:
     uhal.setLogLevelTo( uhal.LogLevel.ERROR )
 
-from gempython.utils.wrappers import runCommand
-cmd = ["amc_info_uhal.py","--shelf=%i"%options.shelf,"-s%i"%options.slot,"--short"]
-runCommand(cmd)
-
 import ROOT as r
 filename = options.filename
 myF = r.TFile(filename,'recreate')
@@ -111,6 +107,11 @@ utime[0] = int(time.time())
 startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
 print startTime
 Date = startTime
+
+from gempython.tools.amc_user_functions_uhal import *
+amcBoard = getAMCObject(options.slot, options.shelf, options.debug)
+printSystemSCAInfo(amcBoard, options.debug)
+printSystemTTCInfo(amcBoard, options.debug)
 
 ohboard = getOHObject(options.slot,options.gtx,options.shelf,options.debug)
 

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -63,6 +63,9 @@ myT.Branch( 'Nhits', Nhits, 'Nhits/I' )
 vfatN = array( 'i', [ 0 ] )
 myT.Branch( 'vfatN', vfatN, 'vfatN/I' )
 
+vfatID = array( 'i', [-1] )
+myT.Branch( 'vfatID', vfatID, 'vfatID/I' ) #Hex Chip ID of VFAT
+
 vfatCH = array( 'i', [ 0 ] )
 myT.Branch( 'vfatCH', vfatCH, 'vfatCH/I' )
 
@@ -156,6 +159,7 @@ try:
         for i in range(0,24):
             if (mask >> i) & 0x1: continue
             vfatN[0] = i
+            vfatID[0] = getChipID(ohboard, options.gtx, vfat, options.debug)
             dataNow = scanData[i]
             trimRange[0] = (0x07 & readVFAT(ohboard,options.gtx, i,"ContReg3"))
             trimDAC[0]   = (0x1f & readVFAT(ohboard,options.gtx, i,"VFATChannels.ChanReg%d"%(scCH)))

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -45,6 +45,10 @@ if options.debug:
 else:
     uhal.setLogLevelTo( uhal.LogLevel.ERROR )
 
+from gempython.utils.wrappers import runCommand
+cmd = ["amc_info_uhal.py","--shelf=%i"%options.shelf,"-s%i"%options.slot,"--short"]
+runCommand(cmd)
+
 import ROOT as r
 filename = options.filename
 myF = r.TFile(filename,'recreate')

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -159,7 +159,7 @@ try:
         for i in range(0,24):
             if (mask >> i) & 0x1: continue
             vfatN[0] = i
-            vfatID[0] = getChipID(ohboard, options.gtx, vfat, options.debug)
+            vfatID[0] = getChipID(ohboard, options.gtx, i, options.debug)
             dataNow = scanData[i]
             trimRange[0] = (0x07 & readVFAT(ohboard,options.gtx, i,"ContReg3"))
             trimDAC[0]   = (0x1f & readVFAT(ohboard,options.gtx, i,"VFATChannels.ChanReg%d"%(scCH)))

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -36,10 +36,6 @@ if options.debug:
 else:
     uhal.setLogLevelTo( uhal.LogLevel.ERROR )
 
-from gempython.utils.wrappers import runCommand
-cmd = ["amc_info_uhal.py","--shelf=%i"%options.shelf,"-s%i"%options.slot,"--short"]
-runCommand(cmd)
-
 import ROOT as r
 filename = options.filename
 myF = r.TFile(filename,'recreate')
@@ -76,6 +72,11 @@ utime[0] = int(time.time())
 startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
 print startTime
 Date = startTime
+
+from gempython.tools.amc_user_functions_uhal import *
+amcBoard = getAMCObject(options.slot, options.shelf, options.debug)
+printSystemSCAInfo(amcBoard, options.debug)
+printSystemTTCInfo(amcBoard, options.debug)
 
 ohboard = getOHObject(options.slot,options.gtx,options.shelf,options.debug)
 

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -115,7 +115,7 @@ try:
             for i in range(0,24):
             	if (mask >> i) & 0x1: continue
                 vfatN[0] = i
-                vfatID[0] = getChipID(ohboard, options.gtx, vfat, options.debug)
+                vfatID[0] = getChipID(ohboard, options.gtx, i, options.debug)
                 dataNow      = scanData[i]
                 trimRange[0] = (0x07 & readVFAT(ohboard,options.gtx, i,"ContReg3"))
                 for VC in range(THRESH_MAX-THRESH_MIN+1):

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -55,6 +55,8 @@ Nhits = array( 'i', [ 0 ] )
 myT.Branch( 'Nhits', Nhits, 'Nhits/I' )
 vfatN = array( 'i', [ 0 ] )
 myT.Branch( 'vfatN', vfatN, 'vfatN/I' )
+vfatID = array( 'i', [-1] )
+myT.Branch( 'vfatID', vfatID, 'vfatID/I' ) #Hex Chip ID of VFAT
 vfatCH = array( 'i', [ 0 ] )
 myT.Branch( 'vfatCH', vfatCH, 'vfatCH/I' )
 trimRange = array( 'i', [ 0 ] )
@@ -113,6 +115,7 @@ try:
             for i in range(0,24):
             	if (mask >> i) & 0x1: continue
                 vfatN[0] = i
+                vfatID[0] = getChipID(ohboard, options.gtx, vfat, options.debug)
                 dataNow      = scanData[i]
                 trimRange[0] = (0x07 & readVFAT(ohboard,options.gtx, i,"ContReg3"))
                 for VC in range(THRESH_MAX-THRESH_MIN+1):

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -36,6 +36,10 @@ if options.debug:
 else:
     uhal.setLogLevelTo( uhal.LogLevel.ERROR )
 
+from gempython.utils.wrappers import runCommand
+cmd = ["amc_info_uhal.py","--shelf=%i"%options.shelf,"-s%i"%options.slot,"--short"]
+runCommand(cmd)
+
 import ROOT as r
 filename = options.filename
 myF = r.TFile(filename,'recreate')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses: https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/138

Requires: https://github.com/cms-gem-daq-project/gem-plotting-tools/pull/51

Additionally when `confChamber.py` calls `readBackCheck(...)` it will now check the ChipID of the VFATs being configured against what is supplied in the input config files.

Note that as a result new configuration files (e.g. `vfatConfig.txt` and `chConfig.txt`) would need to be generated which have a `ChipID` column (shown in integer representation).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
As we move forward eventually we will be configuring with the information that will be stored in the database.  We should be able to cross-check that the info stored for a given VFAT in the database matches the VFAT that is being configured on the hardware.  The best way to do this is to compare the supplied `vfatID` with the `ChipID1` register on the VFAT since they should be identical.

Additionally in our calibration data there is no way to know which VFATs were used for a given run.  Now all produced TTree's by our calibration scans will include the `vfatID` branch which stores the value of the `ChipID1` register. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Took new measurements, analyzed them, and configured from the produced config files as shown:

http://cmsonline.cern.ch/cms-elog/1016357
http://cmsonline.cern.ch/cms-elog/1016594

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
