### PR TITLE
Suppressing echo statements from setup scripts

### DIFF
--- a/setup/paths.sh
+++ b/setup/paths.sh
@@ -1,9 +1,9 @@
 # Setup cmsgemos
-echo "Checking paths" 
+# echo "Checking paths" 
 
 #export BUILD_HOME=<your path>/cmsgemos/../
 if [[ -n "$BUILD_HOME" ]]; then
-    echo BUILD_HOME $BUILD_HOME
+    ; # echo BUILD_HOME $BUILD_HOME
 else
     echo "BUILD_HOME not set, please set BUILD_HOME to the directory above the root of your repository"
     echo " (export BUILD_HOME=<your path>/cmsgemos/../) and then rerun this script"
@@ -12,7 +12,7 @@ fi
 
 #export DATA_PATH=/<your>/<data>/<directory>
 if [[ -n "$DATA_PATH" ]]; then
-    echo DATA_PATH $DATA_PATH
+    ; # echo DATA_PATH $DATA_PATH
 else
     echo "DATA_PATH not set, please set DATA_PATH to a directory where data files created by scan applications will be written"
     echo " (export DATA_PATH=<your>/<data>/<directory>/) and then rerun this script"
@@ -21,7 +21,7 @@ fi
 
 # Checking GEM_PYTHON_PATH
 if [[ -n "$GEM_PYTHON_PATH" ]]; then
-    echo GEM_PYTHON_PATH $GEM_PYTHON_PATH
+    ; # echo GEM_PYTHON_PATH $GEM_PYTHON_PATH
 else
     echo "GEM_PYTHON_PATH not set, please source \$BUILD_HOME/cmsgemos/setup/paths.sh"
     return
@@ -29,9 +29,10 @@ fi
 
 # Checking GEM_PLOTTING_PROJECT
 if [[ -n "$GEM_PLOTTING_PROJECT" ]]; then
-    echo GEM_PLOTTING_PROJECT $GEM_PLOTTING_PROJECT
+    ; # echo GEM_PLOTTING_PROJECT $GEM_PLOTTING_PROJECT
 else
     echo "GEM_PLOTTING_PROJECT not set, please source \$BUILD_HOME/gem-plotting-tools/setup/paths.sh"
+    return
 fi
 
 # Adding Scan Applications to Path
@@ -39,4 +40,4 @@ export "PATH=$PATH:$BUILD_HOME/vfatqc-python-scripts"
 export "PYTHONPATH=$PYTHONPATH:$BUILD_HOME/vfatqc-python-scripts"
 
 # Done
-echo "Setup Complete"
+# echo "Setup Complete"


### PR DESCRIPTION
* `echo`s in environment setup scripts are often problematic, removing for now in favour of a shell function to print the environment
* `echo`s in cases of a failure will remain
