### PR TITLE
Fix missing tree value vfatID in non perchannel scans

### DIFF
--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -155,7 +155,8 @@ try:
         sys.stdout.flush()
         for i in range(0,24):
             if (mask >> i) & 0x1: continue
-            vfatN[0] = i
+            vfatN[0]     = i
+            vfatID[0]    = getChipID(ohboard, options.gtx, i, options.debug)
             dataNow      = scanData[i]
             trimRange[0] = (0x07 & readVFAT(ohboard,options.gtx, i,"ContReg3"))
             for VC in range(THRESH_MAX-THRESH_MIN+1):


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
