### PR TITLE
Bug Fix: legacy vfatN array undefined and generating exception

### DIFF
--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -166,12 +166,9 @@ try:
         startScanModule(ohboard, options.gtx, useUltra=True, debug=options.debug)
         scanData = getUltraScanResults(ohboard, options.gtx, THRESH_MAX - THRESH_MIN + 1, options.debug)
         sys.stdout.flush()
-        for i in range(0,24):
-            if (mask >> i) & 0x1: continue
-            vfatN[0]     = i
-            vfatID[0]    = getChipID(ohboard, options.gtx, i, options.debug)
-            dataNow      = scanData[i]
-            trimRange[0] = (0x07 & readVFAT(ohboard,options.gtx, i,"ContReg3"))
+        for vfat in range(0,24):
+            if (mask >> vfat) & 0x1: continue
+            dataNow      = scanData[vfat]
             for VC in range(THRESH_MAX-THRESH_MIN+1):
                 vth1  = int((dataNow[VC] & 0xff000000) >> 24)
                 Nhits = int(dataNow[VC] & 0xffffff)


### PR DESCRIPTION
removed unnecessary register access, and resolving a variable not defined exception.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When testing threshold scan with trigger data by @AndrewLevin an exception is generated by a legacy array not being removed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Resolving an exception

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change is trivial.  Pretty sure this solves it.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
