### PR TITLE
New Feature [WIP]: Better Trimming for VFAT3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ preprpm: default
 	$(MakeDir) $(ScriptDir)
 	@cp -rf run_scans.py   $(ScriptDir)
 	@cp -rf trimChamber.py $(ScriptDir)
+	@cp -rf trimChamberV3.py $(ScriptDir)
 	@cp -rf fastLatency.py $(ScriptDir)
 	@cp -rf ultra*.py      $(ScriptDir)
 	@cp -rf conf*.py       $(ScriptDir)

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ default:
 	$(MakeDir) $(PackageDir)
 	@cp -rf qcoptions.py $(PackageDir)
 	@cp -rf qcutilities.py $(PackageDir)
+	@cp -rf treeStructure.py $(PackageDir)
 	@echo "__path__ = __import__('pkgutil').extend_path(__path__, __name__)" > pkg/$(Namespace)/__init__.py
 	@cp -rf __init__.py $(PackageDir)
 

--- a/confChamber.py
+++ b/confChamber.py
@@ -7,11 +7,11 @@ Modified by: Eklavya Sarkar eklavya.sarkar@cern.ch
 """
 
 from array import array
-from ...tools.vfat_user_functions_xhal import *
-from ...gemplotting.mapping.chamberInfo import chamber_vfatDACSettings
-from ...vfatqc.qcoptions import parser
-from ...vfatqc.qcutilities import inputOptionsValid, setChannelRegisters
-#from ...vfatqc.qcutilities import readBackCheck 
+from gempython.tools.vfat_user_functions_xhal import *
+from gempython.gemplotting.mapping.chamberInfo import chamber_vfatDACSettings
+from gempython.vfatqc.qcoptions import parser
+from gempython.vfatqc.qcutilities import inputOptionsValid, setChannelRegisters
+#from gempython.vfatqc.qcutilities import readBackCheck 
 
 parser.add_option("--chConfig", type="string", dest="chConfig", default=None,
                   help="Specify file containing channel settings from anaUltraSCurve", metavar="chConfig")

--- a/confChamber.py
+++ b/confChamber.py
@@ -1,164 +1,166 @@
 #!/bin/env python
-"""
-Script to configure the VFATs on a GEM chamber
-By: Cameron Bravo c.bravo@cern.ch
-Modified by: Eklavya Sarkar eklavya.sarkar@cern.ch
-             Brian Dorney brian.l.dorney@cern.ch
-"""
 
-from array import array
-from gempython.tools.vfat_user_functions_xhal import *
-from gempython.gemplotting.mapping.chamberInfo import chamber_vfatDACSettings
-from gempython.vfatqc.qcoptions import parser
-from gempython.vfatqc.qcutilities import inputOptionsValid, setChannelRegisters
-#from gempython.vfatqc.qcutilities import readBackCheck 
-
-parser.add_option("--chConfig", type="string", dest="chConfig", default=None,
-                  help="Specify file containing channel settings from anaUltraSCurve", metavar="chConfig")
-parser.add_option("--compare", action="store_true", dest="compare",
-                  help="When supplied with {chConfig, filename, vfatConfig} compares current reg values with those stored in input files", metavar="compare")
-parser.add_option("--filename", type="string", dest="filename", default=None,
-                  help="Specify file containing settings information", metavar="filename")
-parser.add_option("--run", action="store_true", dest="run",
-                  help="Set VFATs to run mode", metavar="run")
-parser.add_option("--vfatConfig", type="string", dest="vfatConfig", default=None,
-                  help="Specify file containing VFAT settings from anaUltraThreshold", metavar="vfatConfig")
-parser.add_option("--vt1", type="int", dest="vt1",
-                  help="VThreshold1 or CFG_THR_ARM_DAC value for all VFATs", metavar="vt1", default=100)
-parser.add_option("--vt2", type="int", dest="vt2",
-                  help="VThreshold2 DAC value for all VFATs (v2b electronics only)", metavar="vt2", default=0)
-parser.add_option("--vt1bump", type="int", dest="vt1bump",
-                  help="VThreshold1 DAC bump value for all VFATs", metavar="vt1bump", default=0)
-parser.add_option("--zeroChan", action="store_true", dest="zeroChan",
-                  help="Zero all channel registers", metavar="zeroChan")
-
-(options, args) = parser.parse_args()
-
-import subprocess,datetime
-startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
-print startTime
-Date = startTime
-
-vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
-print 'opened connection'
-
-# Check options
-if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
-    exit(os.EX_USAGE)
-    pass
-
-if options.gtx in chamber_vfatDACSettings.keys():
-    print "Configuring VFATs with chamber_vfatDACSettings dictionary values"
-    for key in chamber_vfatDACSettings[options.gtx]:
-        vfatBoard.paramsDefVals[key] = chamber_vfatDACSettings[options.gtx][key]
-vfatBoard.biasAllVFATs(options.vfatmask)
-print 'biased VFATs'
-
-if not options.compare:
-    vfatBoard.setVFATThresholdAll(options.vfatmask, options.vt1, options.vt2)
-    if vfatBoard.parentOH.parentAMC.fwVersion > 2:
-        print('Set CFG_THR_ARM_DAC to %i'%options.vt1)
+if __name__ == '__main__':
+    """
+    Script to configure the VFATs on a GEM chamber
+    By: Cameron Bravo c.bravo@cern.ch
+    Modified by: Eklavya Sarkar eklavya.sarkar@cern.ch
+                 Brian Dorney brian.l.dorney@cern.ch
+    """
+    
+    from array import array
+    from gempython.tools.vfat_user_functions_xhal import *
+    from gempython.gemplotting.mapping.chamberInfo import chamber_vfatDACSettings
+    from gempython.vfatqc.qcoptions import parser
+    from gempython.vfatqc.qcutilities import inputOptionsValid, setChannelRegisters
+    #from gempython.vfatqc.qcutilities import readBackCheck 
+    
+    parser.add_option("--chConfig", type="string", dest="chConfig", default=None,
+                      help="Specify file containing channel settings from anaUltraSCurve", metavar="chConfig")
+    parser.add_option("--compare", action="store_true", dest="compare",
+                      help="When supplied with {chConfig, filename, vfatConfig} compares current reg values with those stored in input files", metavar="compare")
+    parser.add_option("--filename", type="string", dest="filename", default=None,
+                      help="Specify file containing settings information", metavar="filename")
+    parser.add_option("--run", action="store_true", dest="run",
+                      help="Set VFATs to run mode", metavar="run")
+    parser.add_option("--vfatConfig", type="string", dest="vfatConfig", default=None,
+                      help="Specify file containing VFAT settings from anaUltraThreshold", metavar="vfatConfig")
+    parser.add_option("--vt1", type="int", dest="vt1",
+                      help="VThreshold1 or CFG_THR_ARM_DAC value for all VFATs", metavar="vt1", default=100)
+    parser.add_option("--vt2", type="int", dest="vt2",
+                      help="VThreshold2 DAC value for all VFATs (v2b electronics only)", metavar="vt2", default=0)
+    parser.add_option("--vt1bump", type="int", dest="vt1bump",
+                      help="VThreshold1 DAC bump value for all VFATs", metavar="vt1bump", default=0)
+    parser.add_option("--zeroChan", action="store_true", dest="zeroChan",
+                      help="Zero all channel registers", metavar="zeroChan")
+    
+    (options, args) = parser.parse_args()
+    
+    import subprocess,datetime
+    startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
+    print startTime
+    Date = startTime
+    
+    vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
+    print 'opened connection'
+    
+    # Check options
+    if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
+        exit(os.EX_USAGE)
+        pass
+    
+    if options.gtx in chamber_vfatDACSettings.keys():
+        print "Configuring VFATs with chamber_vfatDACSettings dictionary values"
+        for key in chamber_vfatDACSettings[options.gtx]:
+            vfatBoard.paramsDefVals[key] = chamber_vfatDACSettings[options.gtx][key]
+    vfatBoard.biasAllVFATs(options.vfatmask)
+    print 'biased VFATs'
+    
+    if not options.compare:
+        vfatBoard.setVFATThresholdAll(options.vfatmask, options.vt1, options.vt2)
+        if vfatBoard.parentOH.parentAMC.fwVersion > 2:
+            print('Set CFG_THR_ARM_DAC to %i'%options.vt1)
+        else:
+            print('Set VThreshold1 to %i'%options.vt1)
+            print('Set VThreshold2 to %i'%options.vt2)
+    
+    if options.run:
+        vfatBoard.setRunModeAll(options.vfatmask, True)
+        print 'VFATs set to run mode'
     else:
-        print('Set VThreshold1 to %i'%options.vt1)
-        print('Set VThreshold2 to %i'%options.vt2)
-
-if options.run:
-    vfatBoard.setRunModeAll(options.vfatmask, True)
-    print 'VFATs set to run mode'
-else:
-    vfatBoard.setRunModeAll(options.vfatmask, False)
-
-import ROOT as r
-if options.filename:
-    try:
-        inF = r.TFile(options.filename)
-        chTree = inF.Get("scurveFitTree")
-        dict_readBack = {}
-        if vfatBoard.parentOH.parentAMC.fwVersion > 2:
-            # Need some pre-string append that is "VFAT_CHANNELS.CHANNEL"
-            dict_readBack = { "trimDAC":"ARM_TRIM_AMPLITUDE", "trimPolarity":"ARM_TRIM_POLARITY", "mask":"MASK" }
-        else:
-            dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg" }
-            pass
-
-        if not options.compare:
-            print 'Configuring Channel Registers based on %s'%options.filename        
-            setChannelRegisters(vfatBoard, chTree, options.vfatmask)
-            pass
- 
-        #print 'Comparing Currently Stored Channel Registers with %s'%options.filename
-        #readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
-
-    except Exception as e:
-        print '%s does not seem to exist'%options.filename
-        print e
-
-if options.chConfig:
-    try:
-        chTree = r.TTree('chTree','Tree holding Channel Configuration Parameters')
-        chTree.ReadFile(options.chConfig)
-        dict_readBack = {}
-        if vfatBoard.parentOH.parentAMC.fwVersion > 2:
-            # Need some pre-string append that is "VFAT_CHANNELS.CHANNEL"
-            # but that needs to be done in readBackCheck(...) when looping over channels
-            dict_readBack = { "trimDAC":"ARM_TRIM_AMPLITUDE", "trimPolarity":"ARM_TRIM_POLARITY", "mask":"MASK" }
-        else:
-            dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg" }
-
-        if not options.compare:
-            print 'Configuring Channel Registers based on %s'%options.chConfig
-            setChannelRegisters(vfatBoard, chTree, options.vfatmask)
-            pass
-
-        #print 'Comparing Currently Stored Channel Registers with %s'%options.chConfig
-        #readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
-
-    except Exception as e:
-        print '%s does not seem to exist'%options.filename
-        print e
-
-if options.zeroChan:    
-    print("zero'ing all channel registers")    
-    rpcResp = vfatBoard.setAllChannelRegisters(vfatMask=options.vfatmask)
-                
-    if rpcResp != 0:
-        raise Exception("RPC response was non-zero, zero'ing all channel registers failed")
-    pass
-
-if options.vfatConfig:
-    try:
-        vfatTree = r.TTree('vfatTree','Tree holding VFAT Configuration Parameters')
-        vfatTree.ReadFile(options.vfatConfig)
-        #dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3" }
-
-        if not options.compare:
-            print 'Configuring VFAT Registers based on %s'%options.vfatConfig
-
-            for event in vfatTree :
-                # Skip masked vfats
-                if (options.vfatmask >> int(event.vfatN)) & 0x1:
-                    continue
-                
-                # Tell user whether CFG_THR_ARM_DAC or VThreshold1 is being written
-                if vfatBoard.parentOH.parentAMC.fwVersion > 2:
-                    print 'Set link %d VFAT%d CFG_THR_ARM_DAC to %i'%(options.gtx,event.vfatN,event.vt1+options.vt1bump)
-                else:
-                    print 'Set link %d VFAT%d VThreshold1 to %i'%(options.gtx,event.vfatN,event.vt1+options.vt1bump)
-                
-                # Write CFG_THR_ARM_DAC or VThreshold1
-                vfatBoard.setVFATThreshold(chip=int(event.vfatN), vt1=int(event.vt1+options.vt1bump))
-
-                # Write trimRange (only supported for v2b electronics right now)
-                if not (vfatBoard.parentOH.parentAMC.fwVersion > 2):
-                    vfatBoard.writeVFAT(int(event.vfatN), "ContReg3", int(event.trimRange),options.debug)
-        
-        #print 'Comparing Curently Stored VFAT Registers with %s'%options.vfatConfig
-        #if options.vt1bump != 0:
-        #    print "Mismatches between write & readback valus for VThreshold1 should be exactly %i" %(options.vt1bump)
-        #readBackCheck(vfatTree, dict_readBack, ohboard, options.gtx)
-
-    except Exception as e:
-        print '%s does not seem to exist'%options.filename
-        print e
-        
-print 'Chamber Configured'
+        vfatBoard.setRunModeAll(options.vfatmask, False)
+    
+    import ROOT as r
+    if options.filename:
+        try:
+            inF = r.TFile(options.filename)
+            chTree = inF.Get("scurveFitTree")
+            dict_readBack = {}
+            if vfatBoard.parentOH.parentAMC.fwVersion > 2:
+                # Need some pre-string append that is "VFAT_CHANNELS.CHANNEL"
+                dict_readBack = { "trimDAC":"ARM_TRIM_AMPLITUDE", "trimPolarity":"ARM_TRIM_POLARITY", "mask":"MASK" }
+            else:
+                dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg" }
+                pass
+    
+            if not options.compare:
+                print 'Configuring Channel Registers based on %s'%options.filename        
+                setChannelRegisters(vfatBoard, chTree, options.vfatmask)
+                pass
+     
+            #print 'Comparing Currently Stored Channel Registers with %s'%options.filename
+            #readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
+    
+        except Exception as e:
+            print '%s does not seem to exist'%options.filename
+            print e
+    
+    if options.chConfig:
+        try:
+            chTree = r.TTree('chTree','Tree holding Channel Configuration Parameters')
+            chTree.ReadFile(options.chConfig)
+            dict_readBack = {}
+            if vfatBoard.parentOH.parentAMC.fwVersion > 2:
+                # Need some pre-string append that is "VFAT_CHANNELS.CHANNEL"
+                # but that needs to be done in readBackCheck(...) when looping over channels
+                dict_readBack = { "trimDAC":"ARM_TRIM_AMPLITUDE", "trimPolarity":"ARM_TRIM_POLARITY", "mask":"MASK" }
+            else:
+                dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg" }
+    
+            if not options.compare:
+                print 'Configuring Channel Registers based on %s'%options.chConfig
+                setChannelRegisters(vfatBoard, chTree, options.vfatmask)
+                pass
+    
+            #print 'Comparing Currently Stored Channel Registers with %s'%options.chConfig
+            #readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
+    
+        except Exception as e:
+            print '%s does not seem to exist'%options.filename
+            print e
+    
+    if options.zeroChan:    
+        print("zero'ing all channel registers")    
+        rpcResp = vfatBoard.setAllChannelRegisters(vfatMask=options.vfatmask)
+                    
+        if rpcResp != 0:
+            raise Exception("RPC response was non-zero, zero'ing all channel registers failed")
+        pass
+    
+    if options.vfatConfig:
+        try:
+            vfatTree = r.TTree('vfatTree','Tree holding VFAT Configuration Parameters')
+            vfatTree.ReadFile(options.vfatConfig)
+            #dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3" }
+    
+            if not options.compare:
+                print 'Configuring VFAT Registers based on %s'%options.vfatConfig
+    
+                for event in vfatTree :
+                    # Skip masked vfats
+                    if (options.vfatmask >> int(event.vfatN)) & 0x1:
+                        continue
+                    
+                    # Tell user whether CFG_THR_ARM_DAC or VThreshold1 is being written
+                    if vfatBoard.parentOH.parentAMC.fwVersion > 2:
+                        print 'Set link %d VFAT%d CFG_THR_ARM_DAC to %i'%(options.gtx,event.vfatN,event.vt1+options.vt1bump)
+                    else:
+                        print 'Set link %d VFAT%d VThreshold1 to %i'%(options.gtx,event.vfatN,event.vt1+options.vt1bump)
+                    
+                    # Write CFG_THR_ARM_DAC or VThreshold1
+                    vfatBoard.setVFATThreshold(chip=int(event.vfatN), vt1=int(event.vt1+options.vt1bump))
+    
+                    # Write trimRange (only supported for v2b electronics right now)
+                    if not (vfatBoard.parentOH.parentAMC.fwVersion > 2):
+                        vfatBoard.writeVFAT(int(event.vfatN), "ContReg3", int(event.trimRange),options.debug)
+            
+            #print 'Comparing Curently Stored VFAT Registers with %s'%options.vfatConfig
+            #if options.vt1bump != 0:
+            #    print "Mismatches between write & readback valus for VThreshold1 should be exactly %i" %(options.vt1bump)
+            #readBackCheck(vfatTree, dict_readBack, ohboard, options.gtx)
+    
+        except Exception as e:
+            print '%s does not seem to exist'%options.filename
+            print e
+            
+    print 'Chamber Configured'

--- a/confChamber.py
+++ b/confChamber.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     print 'opened connection'
     
     # Check options
-    if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
+    if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC.fwVersion):
         exit(os.EX_USAGE)
         pass
     

--- a/qcutilities.py
+++ b/qcutilities.py
@@ -105,7 +105,7 @@ def inputOptionsValid(options, amc_major_fw_ver):
         pass
 
     # VThreshold2
-    if ( ("vt2" in dict_options.keys()) and (amc_major_fw_ver < 3): # Only v2b behavior
+    if ( ("vt2" in dict_options.keys()) and (amc_major_fw_ver < 3)): # Only v2b behavior
         if options.vt2 not in range(256):
             print("Invalid VT2 specified: %d, must be in range [0,255]"%(options.vt2))
             return False

--- a/qcutilities.py
+++ b/qcutilities.py
@@ -56,7 +56,7 @@ def inputOptionsValid(options, amc_major_fw_ver):
     dict_options = options.__dict__.keys()
 
     # Cal Phase
-    if "CalPhase" in dict_options.keys():
+    if "CalPhase" in dict_options:
         if amc_major_fw_ver < 3:
             if options.CalPhase < 0 or options.CalPhase > 8:
                 print 'CalPhase must be in the range 0-8'
@@ -70,21 +70,21 @@ def inputOptionsValid(options, amc_major_fw_ver):
         pass
     
     # CFG_CAL_SF
-    if "calSF" in dict_options.keys() and amc_major_fw_ver >= 3: # V3 Behavior only
+    if "calSF" in dict_options and amc_major_fw_ver >= 3: # V3 Behavior only
         if options.calSF < 0 or options.calSF > 3:
             print 'calSF must be in the range 0-3'
             return False
         pass
     
     # Channel Range
-    if (("chMin" in dict_options.keys()) and ("chMax" in dict_options.keys())):
+    if (("chMin" in dict_options) and ("chMax" in dict_options)):
         if not (0 <= options.chMin <= options.chMax < 128):
             print "chMin %d not in [0,%d] or chMax %d not in [%d,127] or chMax < chMin"%(options.chMin,options.chMax,options.chMax,options.chMin)
             return False
         pass
 
     # MSPL or Pulse Stretch
-    if "MSPL" in dict_options.keys():
+    if "MSPL" in dict_options:
         if amc_major_fw_ver < 3:
             if options.MSPL not in range(1,9):
                 print("Invalid MSPL specified: %d, must be in range [1,8]"%(options.MSPL))
@@ -98,14 +98,14 @@ def inputOptionsValid(options, amc_major_fw_ver):
         pass
 
     # step size
-    if "stepSize" in dict_options.keys():
+    if "stepSize" in dict_options:
         if options.stepSize <= 0:
             print("Invalid stepSize specified: %d, must be in range [1, %d]"%(options.stepSize, options.scanmax-options.scanmin))
             return False
         pass
 
     # VThreshold2
-    if ( ("vt2" in dict_options.keys()) and (amc_major_fw_ver < 3)): # Only v2b behavior
+    if ( ("vt2" in dict_options) and (amc_major_fw_ver < 3)): # Only v2b behavior
         if options.vt2 not in range(256):
             print("Invalid VT2 specified: %d, must be in range [0,255]"%(options.vt2))
             return False

--- a/qcutilities.py
+++ b/qcutilities.py
@@ -1,3 +1,118 @@
+def setChannelRegisters(vfatBoard, chTree, mask, debug=False):
+    """
+    vfatBoard - an instance of the HwVFAT class
+    chTree - TTree generated from a chConfig.txt file
+    mask - vfat mask to apply
+    debug - print additional information if True
+    """
+
+    from ctypes import *
+    
+    # Make the cArrays
+    cArray_Masks = (c_uint32 * 3072)()
+    cArray_trimVal = (c_uint32 * 3072)()
+    cArray_trimPol = (c_uint32 * 3072)()
+
+    for event in chTree :
+        # Skip masked vfats
+        if (mask >> int(event.vfatN)) & 0x1:
+            continue
+
+        if (vfatBoard.parentOH.parentAMC.fwVersion > 2):
+            cArray_Masks[128*event.vfatN+event.vfatCH] = event.mask
+            cArray_trimVal[128*event.vfatN+event.vfatCH] = event.trimDAC
+            cArray_trimPol[128*event.vfatN+event.vfatCH] = event.trimPolarity
+        else:
+            if int(event.vfatCH) == 0:        
+                vfatBoard.writeVFAT(ohboard, options.gtx, int(event.vfatN), "ContReg3", int(event.trimRange),options.debug)
+            if event.mask==0 and event.trimDAC==0:
+                continue
+            vfatBoard.setChannelRegister(chip=int(event.vfatN), chan=int(event.vfatCH), mask=int(event.mask), trimARM=int(event.trimDAC), debug=options.debug)
+            pass
+        pass
+    
+    if (vfatBoard.parentOH.parentAMC.fwVersion > 2):
+        rpcResp = vfatBoard.setAllChannelRegisters(
+                chMask=cArray_Masks,
+                trimARM=cArray_trimVal,
+                trimARMPol=cArray_trimPol,
+                vfatMask=mask,
+                debug=debug)
+
+        if rpcResp != 0:
+            raise Exception("RPC response was non-zero, setting trim values for all channels failed")
+        pass
+    return
+
+def inputOptionsValid(options, amc_major_fw_ver):
+    """
+    Sanity check on input options
+
+    options - an optparser.Values instance
+    amc_major_fw_ver - major FW version of the AMC
+    """
+
+    # get the options dictionary
+    dict_options = options.__dict__.keys()
+
+    # Cal Phase
+    if "CalPhase" in dict_options.keys():
+        if amc_major_fw_ver < 3:
+            if options.CalPhase < 0 or options.CalPhase > 8:
+                print 'CalPhase must be in the range 0-8'
+                return False
+            pass
+        else:
+            if options.CalPhase < 0 or options.CalPhase > 7:
+                print 'CalPhase must be in the range 0-7'
+                return False
+            pass
+        pass
+    
+    # CFG_CAL_SF
+    if "calSF" in dict_options.keys() and amc_major_fw_ver >= 3: # V3 Behavior only
+        if options.calSF < 0 or options.calSF > 3:
+            print 'calSF must be in the range 0-3'
+            return False
+        pass
+    
+    # Channel Range
+    if (("chMin" in dict_options.keys()) and ("chMax" in dict_options.keys())):
+        if not (0 <= options.chMin <= options.chMax < 128):
+            print "chMin %d not in [0,%d] or chMax %d not in [%d,127] or chMax < chMin"%(options.chMin,options.chMax,options.chMax,options.chMin)
+            return False
+        pass
+
+    # MSPL or Pulse Stretch
+    if "MSPL" in dict_options.keys():
+        if amc_major_fw_ver < 3:
+            if options.MSPL not in range(1,9):
+                print("Invalid MSPL specified: %d, must be in range [1,8]"%(options.MSPL))
+                return False
+            pass
+        else:
+            if options.MSPL not in range(0,8):
+                print("Invalid MSPL specified: %d, must be in range [1,8]"%(options.MSPL))
+                return False
+            pass
+        pass
+
+    # step size
+    if "stepSize" in dict_options.keys():
+        if options.stepSize <= 0:
+            print("Invalid stepSize specified: %d, must be in range [1, %d]"%(options.stepSize, options.scanmax-options.scanmin))
+            return False
+        pass
+
+    # VThreshold2
+    if ( ("vt2" in dict_options.keys()) and (amc_major_fw_ver < 3): # Only v2b behavior
+        if options.vt2 not in range(256):
+            print("Invalid VT2 specified: %d, must be in range [0,255]"%(options.vt2))
+            return False
+        pass
+
+    return True
+
 def readBackCheck(rootTree, dict_Names, device, gtx, vt1bump=0):
     """
     Given an input set of registers, and expected values of those registers, read from all VFATs on device.gtx to see if there are any differences between written and read values.

--- a/sbitThreshScanParallel.py
+++ b/sbitThreshScanParallel.py
@@ -11,7 +11,7 @@ from ctypes import *
 
 from gempython.tools.vfat_user_functions_xhal import *
 
-from qcoptions import parser
+from gempython.vfatqc.qcoptions import parser
 
 parser.add_option("--arm", action="store_true", dest="scanARM",
                   help="Use only the arming comparator instead of the CFD", metavar="scanARM")

--- a/sbitThreshScanSeries.py
+++ b/sbitThreshScanSeries.py
@@ -11,7 +11,7 @@ from ctypes import *
 
 from gempython.tools.vfat_user_functions_xhal import *
 
-from qcoptions import parser
+from gempython.vfatqc.qcoptions import parser
 
 parser.add_option("--arm", action="store_true", dest="scanARM",
                   help="Use only the arming comparator instead of the CFD", metavar="scanARM")

--- a/treeStructure.py
+++ b/treeStructure.py
@@ -16,12 +16,15 @@ class gemTreeStructure:
 
         self.calPhase = array( 'i', [ 0 ] )
         self.gemTree.Branch( 'calPhase', self.calPhase, 'calPhase/I' )
-        
+
+        self.calSF = array( 'i', [0] )
+        self.gemTree.Branch( 'calSF', self.calSF, 'calSF/I')
+
         self.Dly = array( 'i', [ -1 ] )
         self.gemTree.Branch( 'Dly', self.Dly, 'Dly/I' )
 
         self.isCurrentPulse = array( 'i', [ 0 ] )
-        self.gemTree.Branch( 'isCurrentPulse', isCurrentPulse, 'isCurrentPulse/I')
+        self.gemTree.Branch( 'isCurrentPulse', self.isCurrentPulse, 'isCurrentPulse/I')
         
         self.l1aTime = array( 'i', [ 0 ] )
         self.gemTree.Branch( 'l1aTime', self.l1aTime, 'l1aTime/I' )
@@ -50,7 +53,10 @@ class gemTreeStructure:
         
         self.trimDAC = array( 'i', [ 0 ] )
         self.gemTree.Branch( 'trimDAC', self.trimDAC, 'trimDAC/I' )
-        
+
+        self.trimPolarity = array( 'i', [ 0 ] )
+        self.gemTree.Branch( 'trimPolarity', self.trimPolarity, 'trimPolarity/I' )
+
         self.trimRange = array( 'i', [ 0 ] )
         self.gemTree.Branch( 'trimRange', self.trimRange, 'trimRange/I' )
         
@@ -64,7 +70,7 @@ class gemTreeStructure:
         self.gemTree.Branch( 'vfatCH', self.vfatCH, 'vfatCH/I' )
         
         self.vfatID = array( 'i', [-1] )
-        self.gemTree.Branch( 'vfatID', vfatID, 'vfatID/I' ) #Hex Chip ID of VFAT
+        self.gemTree.Branch( 'vfatID', self.vfatID, 'vfatID/I' ) #Hex Chip ID of VFAT
 
         self.vfatN = array( 'i', [ -1 ] )
         self.gemTree.Branch( 'vfatN', self.vfatN, 'vfatN/I' )
@@ -77,6 +83,9 @@ class gemTreeStructure:
         
         self.vth2 = array( 'i', [ 0 ] )
         self.gemTree.Branch( 'vth2', self.vth2, 'vth2/I' )
+    
+        self.vthr = array( 'i', [ 0 ] 
+        self.gemData.Branch( 'vthr', self.vthr, 'vthr/I' )
 
         self.ztrim = array( 'f', [ 0 ] )
         self.gemTree.Branch( 'ztrim', self.ztrim, 'ztrim/F' )
@@ -98,6 +107,8 @@ class gemTreeStructure:
         
         if "calPhase" in kwargs:
             self.calPhase[0] = kwargs["calPhase"]
+        if "calSF" in kwargs:
+            self.calSF[0] = kwargs["calSF"]
         if "Dly" in kwargs:
             self.Dly[0] = kwargs["Dly"]
         if "isCurrentPulse" in kwargs:
@@ -107,7 +118,7 @@ class gemTreeStructure:
         if "latency" in kwargs:
             self.latency[0] = kwargs["latency"]
         if "link" in kwargs:
-            self.link[0] = kwargs["kwargs"]
+            self.link[0] = kwargs["link"]
         if "pDel" in kwargs:
             self.pDel[0] = kwargs["pDel"]
         if "mspl" in kwargs:
@@ -118,6 +129,8 @@ class gemTreeStructure:
             self.Nhits[0] = kwargs["Nhits"]
         if "trimDAC" in kwargs:
             self.trimDAC[0] = kwargs["trimDAC"]
+        if "trimPolarity" in kwargs:
+            self.trimPolarity[0] = kwargs["trimPolarity"]
         if "trimRange" in kwargs:
             self.trimRange[0] = kwargs["trimRange"]
         if "utime" in kwargs:
@@ -136,6 +149,8 @@ class gemTreeStructure:
             self.vth1[0] = kwargs["vth1"]
         if "vth2" in kwargs:
             self.vth2[0] = kwargs["vth2"]
+        if "vthr" in kwargs:
+            self.vthr[0] = kwargs["vthr"]
         if "ztrim" in kwargs:
             self.ztrim[0] = kwargs["ztrim"]
 

--- a/treeStructure.py
+++ b/treeStructure.py
@@ -25,7 +25,10 @@ class gemTreeStructure:
 
         self.isCurrentPulse = array( 'i', [ 0 ] )
         self.gemTree.Branch( 'isCurrentPulse', self.isCurrentPulse, 'isCurrentPulse/I')
-        
+       
+        self.isZCC = array( 'i', [0] )
+        self.gemTree.Branch( 'isZCC', self.isZCC, 'isZCC/I' )
+
         self.l1aTime = array( 'i', [ 0 ] )
         self.gemTree.Branch( 'l1aTime', self.l1aTime, 'l1aTime/I' )
         
@@ -113,6 +116,8 @@ class gemTreeStructure:
             self.Dly[0] = kwargs["Dly"]
         if "isCurrentPulse" in kwargs:
             self.isCurrentPulse[0] = kwargs["isCurrentPulse"]
+        if "isZCC" in kwargs:
+            self.isZCC[0] = kwargs["isZCC"]
         if "l1aTime" in kwargs:
             self.l1aTime[0] = kwargs["l1aTime"]
         if "latency" in kwargs:

--- a/treeStructure.py
+++ b/treeStructure.py
@@ -19,6 +19,9 @@ class gemTreeStructure:
         
         self.Dly = array( 'i', [ -1 ] )
         self.gemTree.Branch( 'Dly', self.Dly, 'Dly/I' )
+
+        self.isCurrentPulse = array( 'i', [ 0 ] )
+        self.gemTree.Branch( 'isCurrentPulse', isCurrentPulse, 'isCurrentPulse/I')
         
         self.l1aTime = array( 'i', [ 0 ] )
         self.gemTree.Branch( 'l1aTime', self.l1aTime, 'l1aTime/I' )
@@ -97,6 +100,8 @@ class gemTreeStructure:
             self.calPhase[0] = kwargs["calPhase"]
         if "Dly" in kwargs:
             self.Dly[0] = kwargs["Dly"]
+        if "isCurrentPulse" in kwargs:
+            self.isCurrentPulse[0] = kwargs["isCurrentPulse"]
         if "l1aTime" in kwargs:
             self.l1aTime[0] = kwargs["l1aTime"]
         if "latency" in kwargs:

--- a/treeStructure.py
+++ b/treeStructure.py
@@ -87,8 +87,8 @@ class gemTreeStructure:
         self.vth2 = array( 'i', [ 0 ] )
         self.gemTree.Branch( 'vth2', self.vth2, 'vth2/I' )
     
-        self.vthr = array( 'i', [ 0 ] 
-        self.gemData.Branch( 'vthr', self.vthr, 'vthr/I' )
+        self.vthr = array( 'i', [ 0 ] )
+        self.gemTree.Branch( 'vthr', self.vthr, 'vthr/I' )
 
         self.ztrim = array( 'f', [ 0 ] )
         self.gemTree.Branch( 'ztrim', self.ztrim, 'ztrim/F' )

--- a/trimChamberV3.py
+++ b/trimChamberV3.py
@@ -208,7 +208,7 @@ if __name__ == '__main__':
             # C = 100 fF; see VFAT3 manual
             # femto factors cancel
             dict_trimVal[vfat] = (dict_scurvePOIPerChan[vfat] - array_avgScurvePOIPerVFAT[vfat]) / 100 # in volts
-            dict_trimVal[vfat] = int(round(dict_trimVal[vfat] * 1e3 / 0.5)) # in DAC units; arm trim circuit has LSB=0.5mV; see VFAT3 manual
+            dict_trimVal[vfat] = np.round(dict_trimVal[vfat] * 1e3 / 0.5) # in DAC units; arm trim circuit has LSB=0.5mV; see VFAT3 manual
         else:
             array_avgScurvePOIPerVFAT[vfat] = -1
             dict_trimVal[vfat] = dict_scurvePOIPerChan[vfat] * 0 # Set all trim's to zero

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -1,332 +1,334 @@
 #!/bin/env python
-"""
-Script to take latency data using OH ultra scans
-By: Jared Sturdy  (sturdy@cern.ch)
-    Cameron Bravo (c.bravo@cern.ch)
-    Brian Dorney (brian.l.dorney@cern.ch)
-"""
 
-import sys, os, random, time
-from array import array
-from ctypes import *
-
-from gempython.tools.vfat_user_functions_xhal import *
-from gempython.tools.vfat_user_functions_uhal import * #remove this later after making it so amc13 communication doesn't spit bullshit messages
-
-from gempython.vfatqc.qcoptions import parser
-
-parser.add_option("--amc13local", action="store_true", dest="amc13local",
-                  help="Set up for using AMC13 local trigger generator", metavar="amc13local")
-parser.add_option("--fakeTTC", action="store_true", dest="fakeTTC",
-                  help="Set up for using AMC13 local TTC generator", metavar="fakeTTC")
-parser.add_option("--filename", type="string", dest="filename", default="LatencyScanData.root",
-                  help="Specify Output Filename", metavar="filename")
-parser.add_option("--internal", action="store_true", dest="internal",
-                  help="Run a latency scan using the internal calibration pulse", metavar="internal")
-parser.add_option("--randoms", type="int", default=0, dest="randoms",
-                  help="Set up for using AMC13 local trigger generator to generate random triggers with rate specified",
-                  metavar="randoms")
-parser.add_option("--t3trig", action="store_true", dest="t3trig",
-                  help="Set up for using AMC13 T3 trigger input", metavar="t3trig")
-parser.add_option("--throttle", type="int", default=0, dest="throttle",
-                  help="factor by which to throttle the input L1A rate, e.g. new trig rate = L1A rate / throttle", metavar="throttle")
-parser.add_option("--vcal", type="int", dest="vcal",
-                  help="Height of CalPulse in DAC units for all VFATs", metavar="vcal", default=250)
-parser.add_option("--voltageStepPulse", action="store_true",dest="voltageStepPulse", 
-                  help="Calibration Module is set to use voltage step pulsing instead of default current pulse injection", 
-                  metavar="voltageStepPulse")
-parser.add_option("--vt2", type="int", dest="vt2",
-                  help="VThreshold2 DAC value for all VFATs (v2b electronics only)", metavar="vt2", default=0)
-
-parser.set_defaults(scanmin=153,scanmax=172,nevts=500)
-(options, args) = parser.parse_args()
-
-remainder = (options.scanmax-options.scanmin+1) % options.stepSize
-if remainder != 0:
-    options.scanmax = options.scanmax + remainder
-    print "extending scanmax to: ", options.scanmax
-
-if options.debug:
-    uhal.setLogLevelTo(uhal.LogLevel.INFO)
-else:
-    uhal.setLogLevelTo(uhal.LogLevel.ERROR)
-
-from ROOT import TFile,TTree
-filename = options.filename
-myF = TFile(filename,'recreate')
-
-import subprocess,datetime,time
-startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
-print(startTime)
-Date = startTime
-
-# Track the current pulse
-isCurrentPulse = (not options.voltageStepPulse)
-
-# Setup the output TTree
-from gempython.vfatqc.treeStructure import gemTreeStructure
-gemData = gemTreeStructure('latTree','Tree Holding CMS GEM Latency Data',scanmode.LATENCY)
-gemData.setDefaults(options, int(time.time()))
-
-import amc13
-connection_file = "%s/connections.xml"%(os.getenv("GEM_ADDRESS_TABLE_PATH"))
-amc13base  = "gem.shelf%02d.amc13"%(options.shelf)
-amc13board = amc13.AMC13(connection_file,"%s.T1"%(amc13base),"%s.T2"%(amc13base))
-
-# Open rpc connection to hw
-vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
-
-# Check options
-from gempython.vfatqc.qcutilities import inputOptionsValid
-if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
-    exit(os.EX_USAGE)
-    pass
-if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-    if options.scanmin not in range(256) or options.scanmax not in range(256) or not (options.scanmax > options.scanmin):
-        print("Invalid scan parameters specified [min,max] = [%d,%d]"%(options.scanmin,options.scanmax))
-        print("Scan parameters must be in range [0,255] and min < max")
-        exit(1)
-        pass
-else:
-    if options.scanmin not in range(1025) or options.scanmax not in range(1025) or not (options.scanmax > options.scanmin):
-        print("Invalid scan parameters specified [min,max] = [%d,%d]"%(options.scanmin,options.scanmax))
-        print("Scan parameters must be in range [0,1024] and min < max")
-        exit(1)
-        pass
-
-mask = options.vfatmask
-
-try:
-    vfatBoard.setRunModeAll(mask, True, options.debug)
-    vfatBoard.setVFATMSPLAll(mask, options.MSPL, options.debug)
+if __name__ == '__main__':
+    """
+    Script to take latency data using OH ultra scans
+    By: Jared Sturdy  (sturdy@cern.ch)
+        Cameron Bravo (c.bravo@cern.ch)
+        Brian Dorney (brian.l.dorney@cern.ch)
+    """
     
-    if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-        vfatBoard.writeAllVFATs("VThreshold2", options.vt2, mask)
-
-        vals = vfatBoard.readAllVFATs("CalPhase",   0x0)
-        calPhasevals = dict(map(lambda slotID: (slotID, bin(vals[slotID]).count("1")),
-                            range(0,24)))
-        vals = vfatBoard.readAllVFATs("ContReg2",    0x0)
-        msplvals =  dict(map(lambda slotID: (slotID, (1+(vals[slotID]>>4)&0x7)),
-                            range(0,24)))
-        vals = vfatBoard.readAllVFATs("ContReg3",    0x0)
-        trimRangevals = dict(map(lambda slotID: (slotID, (0x07 & vals[slotID])),
-                            range(0,24)))
-        #vfatIDvals = getAllChipIDs(ohboard, options.gtx, 0x0)
-        vals  = vfatBoard.readAllVFATs("VThreshold1", 0x0)
-        vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
-                            range(0,24)))
-        vals  = vfatBoard.readAllVFATs("VThreshold2", 0x0)
-        vt2vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
-                            range(0,24)))
-        vthvals =  dict(map(lambda slotID: (slotID, vt2vals[slotID]-vt1vals[slotID]),
-                            range(0,24)))
+    import sys, os, random, time
+    from array import array
+    from ctypes import *
+    
+    from gempython.tools.vfat_user_functions_xhal import *
+    from gempython.tools.vfat_user_functions_uhal import * #remove this later after making it so amc13 communication doesn't spit bullshit messages
+    
+    from gempython.vfatqc.qcoptions import parser
+    
+    parser.add_option("--amc13local", action="store_true", dest="amc13local",
+                      help="Set up for using AMC13 local trigger generator", metavar="amc13local")
+    parser.add_option("--fakeTTC", action="store_true", dest="fakeTTC",
+                      help="Set up for using AMC13 local TTC generator", metavar="fakeTTC")
+    parser.add_option("--filename", type="string", dest="filename", default="LatencyScanData.root",
+                      help="Specify Output Filename", metavar="filename")
+    parser.add_option("--internal", action="store_true", dest="internal",
+                      help="Run a latency scan using the internal calibration pulse", metavar="internal")
+    parser.add_option("--randoms", type="int", default=0, dest="randoms",
+                      help="Set up for using AMC13 local trigger generator to generate random triggers with rate specified",
+                      metavar="randoms")
+    parser.add_option("--t3trig", action="store_true", dest="t3trig",
+                      help="Set up for using AMC13 T3 trigger input", metavar="t3trig")
+    parser.add_option("--throttle", type="int", default=0, dest="throttle",
+                      help="factor by which to throttle the input L1A rate, e.g. new trig rate = L1A rate / throttle", metavar="throttle")
+    parser.add_option("--vcal", type="int", dest="vcal",
+                      help="Height of CalPulse in DAC units for all VFATs", metavar="vcal", default=250)
+    parser.add_option("--voltageStepPulse", action="store_true",dest="voltageStepPulse", 
+                      help="Calibration Module is set to use voltage step pulsing instead of default current pulse injection", 
+                      metavar="voltageStepPulse")
+    parser.add_option("--vt2", type="int", dest="vt2",
+                      help="VThreshold2 DAC value for all VFATs (v2b electronics only)", metavar="vt2", default=0)
+    
+    parser.set_defaults(scanmin=153,scanmax=172,nevts=500)
+    (options, args) = parser.parse_args()
+    
+    remainder = (options.scanmax-options.scanmin+1) % options.stepSize
+    if remainder != 0:
+        options.scanmax = options.scanmax + remainder
+        print "extending scanmax to: ", options.scanmax
+    
+    if options.debug:
+        uhal.setLogLevelTo(uhal.LogLevel.INFO)
     else:
-        vals  = vfatBoard.readAllVFATs("CFG_THR_ARM_DAC", mask)
-        vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
-                            range(0,24)))
-        vals = vfatBoard.readAllVFATs("CFG_PULSE_STRETCH", mask)
-        msplvals =  dict(map(lambda slotID: (slotID, vals[slotID]),
-                             range(0,24)))
-
-    # Stop triggers
-    vfatBoard.parentOH.parentAMC.blockL1A()
-    amc13board.enableLocalL1A(False)
-    amc13board.resetCounters()
-
-    # Check to see if an ultra scan is already running
+        uhal.setLogLevelTo(uhal.LogLevel.ERROR)
+    
+    from ROOT import TFile,TTree
+    filename = options.filename
+    myF = TFile(filename,'recreate')
+    
+    import subprocess,datetime,time
+    startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
+    print(startTime)
+    Date = startTime
+    
+    # Track the current pulse
+    isCurrentPulse = (not options.voltageStepPulse)
+    
+    # Setup the output TTree
+    from gempython.vfatqc.treeStructure import gemTreeStructure
+    gemData = gemTreeStructure('latTree','Tree Holding CMS GEM Latency Data',scanmode.LATENCY)
+    gemData.setDefaults(options, int(time.time()))
+    
+    import amc13
+    connection_file = "%s/connections.xml"%(os.getenv("GEM_ADDRESS_TABLE_PATH"))
+    amc13base  = "gem.shelf%02d.amc13"%(options.shelf)
+    amc13board = amc13.AMC13(connection_file,"%s.T1"%(amc13base),"%s.T2"%(amc13base))
+    
+    # Open rpc connection to hw
+    vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
+    
+    # Check options
+    from gempython.vfatqc.qcutilities import inputOptionsValid
+    if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
+        exit(os.EX_USAGE)
+        pass
     if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-        scanBase = "GEM_AMC.OH.OH%d.ScanController.ULTRA"%(options.gtx)
-        if (vfatBoard.parentOH.parentAMC.readRegister("%s.MONITOR.STATUS"%(scanBase)) > 0):
-            print("Scan was already running, resetting module")
-            vfatBoard.parentOH.parentAMC.writeRegister("%s.RESET"%(scanBase),0x1)
-            time.sleep(0.1)
+        if options.scanmin not in range(256) or options.scanmax not in range(256) or not (options.scanmax > options.scanmin):
+            print("Invalid scan parameters specified [min,max] = [%d,%d]"%(options.scanmin,options.scanmax))
+            print("Scan parameters must be in range [0,255] and min < max")
+            exit(1)
+            pass
+    else:
+        if options.scanmin not in range(1025) or options.scanmax not in range(1025) or not (options.scanmax > options.scanmin):
+            print("Invalid scan parameters specified [min,max] = [%d,%d]"%(options.scanmin,options.scanmax))
+            print("Scan parameters must be in range [0,1024] and min < max")
+            exit(1)
             pass
     
-    amc13nL1A = (amc13board.read(amc13board.Board.T1, "STATUS.GENERAL.L1A_COUNT_HI") << 32) | (amc13board.read(amc13board.Board.T1, "STATUS.GENERAL.L1A_COUNT_LO"))
-    amcnL1A = vfatBoard.parentOH.parentAMC.getL1ACount()
-    if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-        ohnL1A = vfatBoard.parentOH.getL1ACount()
+    mask = options.vfatmask
     
-    print "Initial L1A counts:"
-    print "AMC13: %s"%(amc13nL1A)
-    print "AMC: %s"%(amcnL1A)
-    if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-        print "OH%s: %s"%(options.gtx,ohnL1A)
-    sys.stdout.flush()
-
-    scanChan=128
-    enableCalPulse=False
-    if options.internal:
-        enableCalPulse=True
-        scanChan=0
+    try:
+        vfatBoard.setRunModeAll(mask, True, options.debug)
+        vfatBoard.setVFATMSPLAll(mask, options.MSPL, options.debug)
+        
         if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-            vfatBoard.parentOH.setTriggerSource(0x1)
-        
-        print "stopping cal pulse to all channels"
-        vfatBoard.stopCalPulses(mask, 0, 128)
-        
-        print "Setting channel %i to calpulse"%(scanChan)
-        vfatBoard.setSpecificChannelAllRegisters(chan=scanChan, chMask=0, pulse=1, trimARM=0, vfatMask=mask)
-        vfatBoard.setVFATCalHeightAll(mask, options.vcal, currentPulse=isCurrentPulse)
-
-        # Configure TTC
-        print "attempting to configure TTC"
-        if 0 == vfatBoard.parentOH.parentAMC.configureTTC(options.pDel,options.L1Atime,options.gtx,1,0,0,True):
-            print "TTC configured successfully"
-            vfatBoard.parentOH.parentAMC.getTTCStatus(options.gtx,True)
+            vfatBoard.writeAllVFATs("VThreshold2", options.vt2, mask)
+    
+            vals = vfatBoard.readAllVFATs("CalPhase",   0x0)
+            calPhasevals = dict(map(lambda slotID: (slotID, bin(vals[slotID]).count("1")),
+                                range(0,24)))
+            vals = vfatBoard.readAllVFATs("ContReg2",    0x0)
+            msplvals =  dict(map(lambda slotID: (slotID, (1+(vals[slotID]>>4)&0x7)),
+                                range(0,24)))
+            vals = vfatBoard.readAllVFATs("ContReg3",    0x0)
+            trimRangevals = dict(map(lambda slotID: (slotID, (0x07 & vals[slotID])),
+                                range(0,24)))
+            #vfatIDvals = getAllChipIDs(ohboard, options.gtx, 0x0)
+            vals  = vfatBoard.readAllVFATs("VThreshold1", 0x0)
+            vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
+                                range(0,24)))
+            vals  = vfatBoard.readAllVFATs("VThreshold2", 0x0)
+            vt2vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
+                                range(0,24)))
+            vthvals =  dict(map(lambda slotID: (slotID, vt2vals[slotID]-vt1vals[slotID]),
+                                range(0,24)))
         else:
-            raise Exception('RPC response was non-zero, TTC configuration failed')
-    else:
-        if options.amc13local:
-            amcMask = amc13board.parseInputEnableList("%s"%(options.slot), True)
-            amc13board.reset(amc13board.Board.T1)
-            amc13board.resetCounters()
-            amc13board.resetDAQ()
-            if options.fakeTTC:
-                amc13board.localTtcSignalEnable(options.fakeTTC)
-                pass
-            amc13board.AMCInputEnable(amcMask)
-            amc13board.startRun()
-            # rate should be desired rate * 16
-            # mode may be: 0(per-orbit), 1(per-BX), 2(random)
-            # configureLocalL1A(ena, mode, burst, rate, rules)
-            if options.randoms > 0:
-                amc13board.configureLocalL1A(True, 0, 1, 1, 0) # per-orbit
-                pass
-            if options.t3trig:
-                amc13board.write(amc13board.Board.T1, 'CONF.TTC.T3_TRIG', 0x1)
-                pass
-            # to prevent trigger blocking
-            amc13board.fakeDataEnable(True)
-            # disable the event builder?
-            # amc13board.write(amc13board.Board.T1, 'CONF.DIAG.DISABLE_EVB', 0x1)
-            #amc13board.enableLocalL1A(True)
-            if options.randoms > 0:
-                amc13board.startContinuousL1A()
-                pass
-            pass
-        
-        print "attempting to configure TTC"
+            vals  = vfatBoard.readAllVFATs("CFG_THR_ARM_DAC", mask)
+            vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
+                                range(0,24)))
+            vals = vfatBoard.readAllVFATs("CFG_PULSE_STRETCH", mask)
+            msplvals =  dict(map(lambda slotID: (slotID, vals[slotID]),
+                                 range(0,24)))
+    
+        # Stop triggers
+        vfatBoard.parentOH.parentAMC.blockL1A()
+        amc13board.enableLocalL1A(False)
+        amc13board.resetCounters()
+    
+        # Check to see if an ultra scan is already running
         if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-            vfatBoard.parentOH.setTriggerSource(0x5) # GBT, 0x0 for GTX
-        print "TTC configured successfully"
-        pass
-
-    # Throttle the trigger if requested
-    if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-        vfatBoard.parentOH.setTriggerThrottle(options.throttle)
-    sys.stdout.flush()
-    
-    scanDataSizeVFAT = (options.scanmax-options.scanmin+1)/options.stepSize
-    scanDataSizeNet = scanDataSizeVFAT * 24
-    scanData = (c_uint32 * scanDataSizeNet)()
+            scanBase = "GEM_AMC.OH.OH%d.ScanController.ULTRA"%(options.gtx)
+            if (vfatBoard.parentOH.parentAMC.readRegister("%s.MONITOR.STATUS"%(scanBase)) > 0):
+                print("Scan was already running, resetting module")
+                vfatBoard.parentOH.parentAMC.writeRegister("%s.RESET"%(scanBase),0x1)
+                time.sleep(0.1)
+                pass
         
-    # Determine the scanReg
-    scanReg = "LATENCY"
-    if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-        scanReg = "Latency"
- 
-    # Perform the scan
-    if options.internal:
-        print("Starting scan for channel %i; pulseDelay: %i; L1Atime: %i"%(scanChan, options.pDel, options.L1Atime))
-    else:
-        print("Starting scan")
-    # Not sure I understand why it has to be scanChan+1 below...
-    amc13board.enableLocalL1A(True)
-    vfatBoard.parentOH.parentAMC.enableL1A()
-    rpcResp = vfatBoard.parentOH.performCalibrationScan(scanChan, scanReg, scanData, enableCal=enableCalPulse, currentPulse=isCurrentPulse, nevts=options.nevts, 
-                                                        dacMin=options.scanmin, dacMax=options.scanmax, stepSize=options.stepSize, 
-                                                        mask=options.vfatmask, useExtTrig=(not options.internal))
-
-    if rpcResp != 0:
-        raise Exception('RPC response was non-zero, this inidcates an RPC exception occurred')
-    print("Done scanning, processing output")
+        amc13nL1A = (amc13board.read(amc13board.Board.T1, "STATUS.GENERAL.L1A_COUNT_HI") << 32) | (amc13board.read(amc13board.Board.T1, "STATUS.GENERAL.L1A_COUNT_LO"))
+        amcnL1A = vfatBoard.parentOH.parentAMC.getL1ACount()
+        if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+            ohnL1A = vfatBoard.parentOH.getL1ACount()
+        
+        print "Initial L1A counts:"
+        print "AMC13: %s"%(amc13nL1A)
+        print "AMC: %s"%(amcnL1A)
+        if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+            print "OH%s: %s"%(options.gtx,ohnL1A)
+        sys.stdout.flush()
     
-    print "Final L1A counts:"
-    amc13board.enableLocalL1A(False)
-    vfatBoard.parentOH.parentAMC.blockL1A()
-    amc13nL1Af = (amc13board.read(amc13board.Board.T1, "STATUS.GENERAL.L1A_COUNT_HI") << 32) | (amc13board.read(amc13board.Board.T1, "STATUS.GENERAL.L1A_COUNT_LO"))
-    amcnL1Af = vfatBoard.parentOH.parentAMC.getL1ACount()
-    if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-        ohnL1Af = vfatBoard.parentOH.getL1ACount()
-    print "AMC13: %s, difference %s"%(amc13nL1Af,amc13nL1Af-amc13nL1A)
-    print "AMC: %s, difference %s"%(amcnL1Af,amcnL1Af-amcnL1A)
+        scanChan=128
+        enableCalPulse=False
+        if options.internal:
+            enableCalPulse=True
+            scanChan=0
+            if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+                vfatBoard.parentOH.setTriggerSource(0x1)
+            
+            print "stopping cal pulse to all channels"
+            vfatBoard.stopCalPulses(mask, 0, 128)
+            
+            print "Setting channel %i to calpulse"%(scanChan)
+            vfatBoard.setSpecificChannelAllRegisters(chan=scanChan, chMask=0, pulse=1, trimARM=0, vfatMask=mask)
+            vfatBoard.setVFATCalHeightAll(mask, options.vcal, currentPulse=isCurrentPulse)
     
-    if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-        print "OH%s: %s, difference %s"%(options.gtx,ohnL1Af,ohnL1Af-ohnL1A)
-
-    print("Information on CRC packets")
-    print("\tActually still needs to be implemented (oops) - Brian")
-    # this is the way to do this for v2b
-    #for i in range(24):
-    #  print "Total number of CRC packets for VFAT%s on link %s is %s"%(i, options.gtx, readRegister(ohboard,"GEM_AMC.OH.OH%d.COUNTERS.CRC.INCORRECT.VFAT%d"%(options.gtx,i)) + readRegister(ohboard,"GEM_AMC.OH.OH%d.COUNTERS.CRC.VALID.VFAT%d"%(options.gtx,i)))
-    #for i in range(24):
-    #  print "Number of CRC errors for VFAT%s on link %s is %s"%(i, options.gtx, readRegister(ohboard,"GEM_AMC.OH.OH%d.COUNTERS.CRC.INCORRECT.VFAT%d"%(options.gtx,i)))
-    # for v3 evaldas says I can count number of good & bad CRC eventss w/DAQ_MONITPR as well as number of L1As received by the CTP7 and forwarded to the VFATs with GEM_AMC.TTC.CMD_COUNTERS.L1A
-
-    #amc13board.enableLocalL1A(True)
-    sys.stdout.flush()
-    print("parsing scan data")
-    for vfat in range(0,24):
-        if (mask >> vfat) & 0x1: continue
-        if options.debug:
-            sys.stdout.flush()
-            pass
-        for latReg in range(vfat*scanDataSizeVFAT,(vfat+1)*scanDataSizeVFAT):
-            try:
-                if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-                    gemData.fill(
-                            calPhase = calPhasevals[vfat],
-                            latency = int((scanData[latReg] & 0xff000000) >> 24),
-                            mspl = msplvals[vfat],
-                            Nhits = int(scanData[latReg] & 0xffffff),
-                            trimRange = trimRangevals[vfat],
-                            #vfatID = vfatIDvals[vfat],
-                            vfatN = vfat,
-                            vth = vthvals[vfat],
-                            vth1 = vt1vals[vfat],
-                            vth2 = vt2vals[vfat]
-                            )
-                else:
-                    gemData.fill(
-                            isCurrentPulse = isCurrentPulse,
-                            latency = (options.scanmin + (latReg - vfat*scanDataSizeVFAT) * options.stepSize), 
-                            mspl = msplvals[vfat],
-                            Nev = (scanData[latReg] & 0xffff),
-                            Nhits = ((scanData[latReg]>>16) & 0xffff),
-                            #vfatID = vfatIDvals[vfat],
-                            vfatN = vfat,
-                            vth1 = vt1vals[vfat]
-                            )
+            # Configure TTC
+            print "attempting to configure TTC"
+            if 0 == vfatBoard.parentOH.parentAMC.configureTTC(options.pDel,options.L1Atime,options.gtx,1,0,0,True):
+                print "TTC configured successfully"
+                vfatBoard.parentOH.parentAMC.getTTCStatus(options.gtx,True)
+            else:
+                raise Exception('RPC response was non-zero, TTC configuration failed')
+        else:
+            if options.amc13local:
+                amcMask = amc13board.parseInputEnableList("%s"%(options.slot), True)
+                amc13board.reset(amc13board.Board.T1)
+                amc13board.resetCounters()
+                amc13board.resetDAQ()
+                if options.fakeTTC:
+                    amc13board.localTtcSignalEnable(options.fakeTTC)
                     pass
-
-            except IndexError:
-                print 'Unable to index data for channel %i'%chan
-                print scanData[latReg]
-            finally:
-                if options.debug:
-                    print "vfat%i; lat %i; Nev %i; Nhits %i"%(
-                            gemData.vfatN[0],
-                            gemData.latency[0],
-                            gemData.Nev[0],
-                            gemData.Nhits[0])
+                amc13board.AMCInputEnable(amcMask)
+                amc13board.startRun()
+                # rate should be desired rate * 16
+                # mode may be: 0(per-orbit), 1(per-BX), 2(random)
+                # configureLocalL1A(ena, mode, burst, rate, rules)
+                if options.randoms > 0:
+                    amc13board.configureLocalL1A(True, 0, 1, 1, 0) # per-orbit
+                    pass
+                if options.t3trig:
+                    amc13board.write(amc13board.Board.T1, 'CONF.TTC.T3_TRIG', 0x1)
+                    pass
+                # to prevent trigger blocking
+                amc13board.fakeDataEnable(True)
+                # disable the event builder?
+                # amc13board.write(amc13board.Board.T1, 'CONF.DIAG.DISABLE_EVB', 0x1)
+                #amc13board.enableLocalL1A(True)
+                if options.randoms > 0:
+                    amc13board.startContinuousL1A()
+                    pass
+                pass
+            
+            print "attempting to configure TTC"
+            if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+                vfatBoard.parentOH.setTriggerSource(0x5) # GBT, 0x0 for GTX
+            print "TTC configured successfully"
             pass
-        pass
-    gemData.autoSave("SaveSelf")
-
-    vfatBoard.setRunModeAll(mask, False, options.debug)
-    if options.internal:
-        vfatBoard.parentOH.parentAMC.toggleTTCGen(options.gtx, False)
-        pass
-    elif options.amc13local:
-        amc13board.stopContinuousL1A()
-        amc13board.fakeDataEnable(False)
-        pass
-except Exception as e:
-    gemData.autoSave()
-    print("An exception occurred", e)
-finally:
-    myF.cd()
-    gemData.write()
-    myF.Close()
+    
+        # Throttle the trigger if requested
+        if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+            vfatBoard.parentOH.setTriggerThrottle(options.throttle)
+        sys.stdout.flush()
+        
+        scanDataSizeVFAT = (options.scanmax-options.scanmin+1)/options.stepSize
+        scanDataSizeNet = scanDataSizeVFAT * 24
+        scanData = (c_uint32 * scanDataSizeNet)()
+            
+        # Determine the scanReg
+        scanReg = "LATENCY"
+        if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+            scanReg = "Latency"
+     
+        # Perform the scan
+        if options.internal:
+            print("Starting scan for channel %i; pulseDelay: %i; L1Atime: %i"%(scanChan, options.pDel, options.L1Atime))
+        else:
+            print("Starting scan")
+        # Not sure I understand why it has to be scanChan+1 below...
+        amc13board.enableLocalL1A(True)
+        vfatBoard.parentOH.parentAMC.enableL1A()
+        rpcResp = vfatBoard.parentOH.performCalibrationScan(scanChan, scanReg, scanData, enableCal=enableCalPulse, currentPulse=isCurrentPulse, nevts=options.nevts, 
+                                                            dacMin=options.scanmin, dacMax=options.scanmax, stepSize=options.stepSize, 
+                                                            mask=options.vfatmask, useExtTrig=(not options.internal))
+    
+        if rpcResp != 0:
+            raise Exception('RPC response was non-zero, this inidcates an RPC exception occurred')
+        print("Done scanning, processing output")
+        
+        print "Final L1A counts:"
+        amc13board.enableLocalL1A(False)
+        vfatBoard.parentOH.parentAMC.blockL1A()
+        amc13nL1Af = (amc13board.read(amc13board.Board.T1, "STATUS.GENERAL.L1A_COUNT_HI") << 32) | (amc13board.read(amc13board.Board.T1, "STATUS.GENERAL.L1A_COUNT_LO"))
+        amcnL1Af = vfatBoard.parentOH.parentAMC.getL1ACount()
+        if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+            ohnL1Af = vfatBoard.parentOH.getL1ACount()
+        print "AMC13: %s, difference %s"%(amc13nL1Af,amc13nL1Af-amc13nL1A)
+        print "AMC: %s, difference %s"%(amcnL1Af,amcnL1Af-amcnL1A)
+        
+        if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+            print "OH%s: %s, difference %s"%(options.gtx,ohnL1Af,ohnL1Af-ohnL1A)
+    
+        print("Information on CRC packets")
+        print("\tActually still needs to be implemented (oops) - Brian")
+        # this is the way to do this for v2b
+        #for i in range(24):
+        #  print "Total number of CRC packets for VFAT%s on link %s is %s"%(i, options.gtx, readRegister(ohboard,"GEM_AMC.OH.OH%d.COUNTERS.CRC.INCORRECT.VFAT%d"%(options.gtx,i)) + readRegister(ohboard,"GEM_AMC.OH.OH%d.COUNTERS.CRC.VALID.VFAT%d"%(options.gtx,i)))
+        #for i in range(24):
+        #  print "Number of CRC errors for VFAT%s on link %s is %s"%(i, options.gtx, readRegister(ohboard,"GEM_AMC.OH.OH%d.COUNTERS.CRC.INCORRECT.VFAT%d"%(options.gtx,i)))
+        # for v3 evaldas says I can count number of good & bad CRC eventss w/DAQ_MONITPR as well as number of L1As received by the CTP7 and forwarded to the VFATs with GEM_AMC.TTC.CMD_COUNTERS.L1A
+    
+        #amc13board.enableLocalL1A(True)
+        sys.stdout.flush()
+        print("parsing scan data")
+        for vfat in range(0,24):
+            if (mask >> vfat) & 0x1: continue
+            if options.debug:
+                sys.stdout.flush()
+                pass
+            for latReg in range(vfat*scanDataSizeVFAT,(vfat+1)*scanDataSizeVFAT):
+                try:
+                    if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+                        gemData.fill(
+                                calPhase = calPhasevals[vfat],
+                                latency = int((scanData[latReg] & 0xff000000) >> 24),
+                                mspl = msplvals[vfat],
+                                Nhits = int(scanData[latReg] & 0xffffff),
+                                trimRange = trimRangevals[vfat],
+                                #vfatID = vfatIDvals[vfat],
+                                vfatN = vfat,
+                                vth = vthvals[vfat],
+                                vth1 = vt1vals[vfat],
+                                vth2 = vt2vals[vfat]
+                                )
+                    else:
+                        gemData.fill(
+                                isCurrentPulse = isCurrentPulse,
+                                latency = (options.scanmin + (latReg - vfat*scanDataSizeVFAT) * options.stepSize), 
+                                mspl = msplvals[vfat],
+                                Nev = (scanData[latReg] & 0xffff),
+                                Nhits = ((scanData[latReg]>>16) & 0xffff),
+                                #vfatID = vfatIDvals[vfat],
+                                vfatN = vfat,
+                                vth1 = vt1vals[vfat]
+                                )
+                        pass
+    
+                except IndexError:
+                    print 'Unable to index data for channel %i'%chan
+                    print scanData[latReg]
+                finally:
+                    if options.debug:
+                        print "vfat%i; lat %i; Nev %i; Nhits %i"%(
+                                gemData.vfatN[0],
+                                gemData.latency[0],
+                                gemData.Nev[0],
+                                gemData.Nhits[0])
+                pass
+            pass
+        gemData.autoSave("SaveSelf")
+    
+        vfatBoard.setRunModeAll(mask, False, options.debug)
+        if options.internal:
+            vfatBoard.parentOH.parentAMC.toggleTTCGen(options.gtx, False)
+            pass
+        elif options.amc13local:
+            amc13board.stopContinuousL1A()
+            amc13board.fakeDataEnable(False)
+            pass
+    except Exception as e:
+        gemData.autoSave()
+        print("An exception occurred", e)
+    finally:
+        myF.cd()
+        gemData.write()
+        myF.Close()

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -41,18 +41,9 @@ parser.add_option("--vt2", type="int", dest="vt2",
 parser.set_defaults(scanmin=153,scanmax=172,nevts=500)
 (options, args) = parser.parse_args()
 
-#if options.scanmin not in range(256) or options.scanmax not in range(256) or not (options.scanmax > options.scanmin):
-#    print("Invalid scan parameters specified [min,max] = [%d,%d]"%(options.scanmin,options.scanmax))
-#    print("Scan parameters must be in range [0,255] and min < max")
-#    exit(1)
-
 if options.vt2 not in range(256):
     print("Invalid VT2 specified: %d, must be in range [0,255]"%(options.vt2))
     exit(1)
-
-#if options.MSPL not in range(1,9):
-#    print("Invalid MSPL specified: %d, must be in range [1,8]"%(options.MSPL))
-#    exit(1)
 
 if options.stepSize <= 0:
     print("Invalid stepSize specified: %d, must be in range [1, %d]"%(options.stepSize, options.scanmax-options.scanmin))
@@ -117,6 +108,24 @@ amc13base  = "gem.shelf%02d.amc13"%(options.shelf)
 amc13board = amc13.AMC13(connection_file,"%s.T1"%(amc13base),"%s.T2"%(amc13base))
 
 vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
+if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+    if options.scanmin not in range(256) or options.scanmax not in range(256) or not (options.scanmax > options.scanmin):
+        print("Invalid scan parameters specified [min,max] = [%d,%d]"%(options.scanmin,options.scanmax))
+        print("Scan parameters must be in range [0,255] and min < max")
+        exit(1)
+    
+    if options.MSPL not in range(1,9):
+        print("Invalid MSPL specified: %d, must be in range [1,8]"%(options.MSPL))
+        exit(1)
+else:
+    if options.scanmin not in range(1025) or options.scanmax not in range(1025) or not (options.scanmax > options.scanmin):
+        print("Invalid scan parameters specified [min,max] = [%d,%d]"%(options.scanmin,options.scanmax))
+        print("Scan parameters must be in range [0,255] and min < max")
+        exit(1)
+    
+    if options.MSPL not in range(0,8):
+        print("Invalid MSPL specified: %d, must be in range [1,8]"%(options.MSPL))
+        exit(1)
 
 mask = options.vfatmask
 

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -14,6 +14,7 @@ if __name__ == '__main__':
     
     from gempython.tools.vfat_user_functions_xhal import *
     from gempython.tools.vfat_user_functions_uhal import * #remove this later after making it so amc13 communication doesn't spit bullshit messages
+    from gempython.tools.optohybrid_user_functions_uhal import scanmode
     
     from gempython.vfatqc.qcoptions import parser
     

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -41,10 +41,6 @@ parser.add_option("--vt2", type="int", dest="vt2",
 parser.set_defaults(scanmin=153,scanmax=172,nevts=500)
 (options, args) = parser.parse_args()
 
-if options.vt2 not in range(256):
-    print("Invalid VT2 specified: %d, must be in range [0,255]"%(options.vt2))
-    exit(1)
-
 if options.stepSize <= 0:
     print("Invalid stepSize specified: %d, must be in range [1, %d]"%(options.stepSize, options.scanmax-options.scanmin))
     exit(1)
@@ -62,40 +58,14 @@ else:
 from ROOT import TFile,TTree
 filename = options.filename
 myF = TFile(filename,'recreate')
-myT = TTree('latTree','Tree Holding CMS GEM Latency Data')
-
-isCurrentPulse = array( 'i', [ 0 ] )
-myT.Branch( 'isCurrentPulse', isCurrentPulse, 'isCurrentPulse/I')
-isCurrentPulse[0] = not options.voltageStepPulse
-Nev = array( 'i', [ 0 ] )
-Nev[0] = -1
-myT.Branch( 'Nev', Nev, 'Nev/I' )
-vth = array( 'i', [ 0 ] )
-myT.Branch( 'vth', vth, 'vth/I' )
-vth1 = array( 'i', [ 0 ] )
-myT.Branch( 'vth1', vth1, 'vth1/I' )
-vth2 = array( 'i', [ 0 ] )
-myT.Branch( 'vth2', vth2, 'vth2/I' )
-lat = array( 'i', [ 0 ] )
-myT.Branch( 'lat', lat, 'lat/I' )
-Nhits = array( 'i', [ 0 ] )
-myT.Branch( 'Nhits', Nhits, 'Nhits/I' )
-vfatN = array( 'i', [ 0 ] )
-myT.Branch( 'vfatN', vfatN, 'vfatN/I' )
-mspl = array( 'i', [ -1 ] )
-myT.Branch( 'mspl', mspl, 'mspl/I' )
-vfatCH = array( 'i', [ 0 ] )
-myT.Branch( 'vfatCH', vfatCH, 'vfatCH/I' )
-link = array( 'i', [ 0 ] )
-myT.Branch( 'link', link, 'link/I' )
-link[0] = options.gtx
-utime = array( 'i', [ 0 ] )
-myT.Branch( 'utime', utime, 'utime/I' )
 
 import subprocess,datetime,time
 startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
 print(startTime)
 Date = startTime
+
+# Track the current pulse
+isCurrentPulse = (not options.voltageStepPulse)
 
 # Setup the output TTree
 from treeStructure import gemTreeStructure
@@ -117,6 +87,10 @@ if vfatBoard.parentOH.parentAMC.fwVersion < 3:
     if options.MSPL not in range(1,9):
         print("Invalid MSPL specified: %d, must be in range [1,8]"%(options.MSPL))
         exit(1)
+
+    if options.vt2 not in range(256):
+        print("Invalid VT2 specified: %d, must be in range [0,255]"%(options.vt2))
+        exit(1)
 else:
     if options.scanmin not in range(1025) or options.scanmax not in range(1025) or not (options.scanmax > options.scanmin):
         print("Invalid scan parameters specified [min,max] = [%d,%d]"%(options.scanmin,options.scanmax))
@@ -136,17 +110,24 @@ try:
     if vfatBoard.parentOH.parentAMC.fwVersion < 3:
         vfatBoard.writeAllVFATs("VThreshold2", options.vt2, mask)
 
+        vals = vfatBoard.readAllVFATs("CalPhase",   0x0)
+        calPhasevals = dict(map(lambda slotID: (slotID, bin(vals[slotID]).count("1")),
+                            range(0,24)))
+        vals = vfatBoard.readAllVFATs("ContReg2",    0x0)
+        msplvals =  dict(map(lambda slotID: (slotID, (1+(vals[slotID]>>4)&0x7)),
+                            range(0,24)))
+        vals = vfatBoard.readAllVFATs("ContReg3",    0x0)
+        trimRangevals = dict(map(lambda slotID: (slotID, (0x07 & vals[slotID])),
+                            range(0,24)))
+        #vfatIDvals = getAllChipIDs(ohboard, options.gtx, 0x0)
         vals  = vfatBoard.readAllVFATs("VThreshold1", 0x0)
         vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
                             range(0,24)))
         vals  = vfatBoard.readAllVFATs("VThreshold2", 0x0)
         vt2vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
                             range(0,24)))
-        vthvals =  dict(map(lambda slotID: (slotID, vt2vals[slotID]-vt2vals[slotID]),
+        vthvals =  dict(map(lambda slotID: (slotID, vt2vals[slotID]-vt1vals[slotID]),
                             range(0,24)))
-        vals = vfatBoard.readAllVFATs("ContReg2",    0x0)
-        msplvals =  dict(map(lambda slotID: (slotID, (1+(vals[slotID]>>4)&0x7)),
-                             range(0,24)))
     else:
         vals  = vfatBoard.readAllVFATs("CFG_THR_ARM_DAC", mask)
         vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
@@ -180,14 +161,12 @@ try:
     if vfatBoard.parentOH.parentAMC.fwVersion < 3:
         print "OH%s: %s"%(options.gtx,ohnL1A)
     sys.stdout.flush()
-    #amc13board.enableLocalL1A(True)
 
     scanChan=128
     enableCalPulse=False
     if options.internal:
         enableCalPulse=True
         scanChan=0
-        #vfatBoard.parentOH.parentAMC.blockL1A()
         if vfatBoard.parentOH.parentAMC.fwVersion < 3:
             vfatBoard.parentOH.setTriggerSource(0x1)
         
@@ -196,7 +175,7 @@ try:
         
         print "Setting channel %i to calpulse"%(scanChan)
         vfatBoard.setSpecificChannelAllRegisters(chan=scanChan, chMask=0, pulse=1, trimARM=0, vfatMask=mask)
-        vfatBoard.setVFATCalHeightAll(mask, options.vcal, currentPulse=isCurrentPulse[0])
+        vfatBoard.setVFATCalHeightAll(mask, options.vcal, currentPulse=isCurrentPulse)
 
         # Configure TTC
         print "attempting to configure TTC"
@@ -236,7 +215,6 @@ try:
             pass
         
         print "attempting to configure TTC"
-        #vfatBoard.parentOH.parentAMC.enableL1A()
         if vfatBoard.parentOH.parentAMC.fwVersion < 3:
             vfatBoard.parentOH.setTriggerSource(0x5) # GBT, 0x0 for GTX
         print "TTC configured successfully"
@@ -264,7 +242,7 @@ try:
     # Not sure I understand why it has to be scanChan+1 below...
     amc13board.enableLocalL1A(True)
     vfatBoard.parentOH.parentAMC.enableL1A()
-    rpcResp = vfatBoard.parentOH.performCalibrationScan(scanChan, scanReg, scanData, enableCal=enableCalPulse, currentPulse=isCurrentPulse[0], nevts=options.nevts, 
+    rpcResp = vfatBoard.parentOH.performCalibrationScan(scanChan, scanReg, scanData, enableCal=enableCalPulse, currentPulse=isCurrentPulse, nevts=options.nevts, 
                                                         dacMin=options.scanmin, dacMax=options.scanmax, stepSize=options.stepSize, 
                                                         mask=options.vfatmask, useExtTrig=(not options.internal))
 
@@ -299,36 +277,50 @@ try:
     print("parsing scan data")
     for vfat in range(0,24):
         if (mask >> vfat) & 0x1: continue
-        vfatN[0] = vfat
-        mspl[0]  = msplvals[vfatN[0]]
-        vth1[0]  = vt1vals[vfatN[0]]
-        #vth2[0]  = vt2vals[vfatN[0]]
-        #vth[0]   = vthvals[vfatN[0]]
         if options.debug:
             sys.stdout.flush()
             pass
         for latReg in range(vfat*scanDataSizeVFAT,(vfat+1)*scanDataSizeVFAT):
             try:
                 if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-                    lat[0]   = int((scanData[latReg] & 0xff000000) >> 24)
-                    Nev[0] = options.nevts
-                    Nhits[0] = int(scanData[latReg] & 0xffffff)
+                    gemData.fill(
+                            calPhase = calPhasevals[vfat],
+                            latency = int((scanData[latReg] & 0xff000000) >> 24),
+                            mspl = msplvals[vfat],
+                            Nhits = int(scanData[latReg] & 0xffffff),
+                            trimRange = trimRangevals[vfat],
+                            #vfatID = vfatIDvals[vfat],
+                            vfatN = vfat,
+                            vth = vthvals[vfat],
+                            vth1 = vt1vals[vfat],
+                            vth2 = vt2vals[vfat]
+                            )
                 else:
-                    lat[0] = options.scanmin + (latReg - vfat*scanDataSizeVFAT) * options.stepSize
-                    Nev[0] = scanData[latReg] & 0xffff
-                    Nhits[0] = (scanData[latReg]>>16) & 0xffff
+                    gemData.fill(
+                            isCurrentPulse = isCurrentPulse,
+                            latency = (options.scanmin + (latReg - vfat*scanDataSizeVFAT) * options.stepSize), 
+                            mspl = msplvals[vfat],
+                            Nev = (scanData[latReg] & 0xffff),
+                            Nhits = ((scanData[latReg]>>16) & 0xffff),
+                            #vfatID = vfatIDvals[vfat],
+                            vfatN = vfat,
+                            vth1 = vt1vals[vfat]
+                            )
+                    pass
+
             except IndexError:
                 print 'Unable to index data for channel %i'%chan
                 print scanData[latReg]
-                lat[0]  = -99
-                Nhits[0] = -99
             finally:
                 if options.debug:
-                    print "vfat%i; lat %i; Nev %i; Nhits %i"%(vfatN[0],lat[0],Nev[0],Nhits[0])
-                myT.Fill()
+                    print "vfat%i; lat %i; Nev %i; Nhits %i"%(
+                            gemData.vfatN[0],
+                            gemData.latency[0],
+                            gemData.Nev[0],
+                            gemData.Nhits[0])
             pass
         pass
-    myT.AutoSave("SaveSelf")
+    gemData.AutoSave("SaveSelf")
 
     vfatBoard.setRunModeAll(mask, False, options.debug)
     if options.internal:
@@ -337,7 +329,6 @@ try:
     elif options.amc13local:
         amc13board.stopContinuousL1A()
         amc13board.fakeDataEnable(False)
-        # amc13board.write(amc13board.Board.T1, 'CONF.DIAG.DISABLE_EVB', 0x0)
         pass
 except Exception as e:
     gemData.autoSave()

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -64,7 +64,7 @@ Date = startTime
 isCurrentPulse = (not options.voltageStepPulse)
 
 # Setup the output TTree
-from gempytreeStructure import gemTreeStructure
+from gempython.vfatqc.treeStructure import gemTreeStructure
 gemData = gemTreeStructure('latTree','Tree Holding CMS GEM Latency Data',scanmode.LATENCY)
 gemData.setDefaults(options, int(time.time()))
 

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
     
     # Check options
     from gempython.vfatqc.qcutilities import inputOptionsValid
-    if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
+    if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC.fwVersion):
         exit(os.EX_USAGE)
         pass
     if vfatBoard.parentOH.parentAMC.fwVersion < 3:

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -64,7 +64,7 @@ Date = startTime
 isCurrentPulse = (not options.voltageStepPulse)
 
 # Setup the output TTree
-from treeStructure import gemTreeStructure
+from gempytreeStructure import gemTreeStructure
 gemData = gemTreeStructure('latTree','Tree Holding CMS GEM Latency Data',scanmode.LATENCY)
 gemData.setDefaults(options, int(time.time()))
 
@@ -77,7 +77,7 @@ amc13board = amc13.AMC13(connection_file,"%s.T1"%(amc13base),"%s.T2"%(amc13base)
 vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
 
 # Check options
-from ...vfatqc.qcutilities import inputOptionsValid
+from gempython.vfatqc.qcutilities import inputOptionsValid
 if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
     exit(os.EX_USAGE)
     pass

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -8,6 +8,7 @@ if __name__ == '__main__':
     
     from array import array
     from ctypes import *
+    from gempython.tools.optohybrid_user_functions_uhal import scanmode
     from gempython.tools.vfat_user_functions_xhal import *
     
     from gempython.vfatqc.qcoptions import parser

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -8,9 +8,9 @@ if __name__ == '__main__':
     
     from array import array
     from ctypes import *
-    from ...tools.vfat_user_functions_xhal import *
+    from gempython.tools.vfat_user_functions_xhal import *
     
-    from ...vfatqc.qcoptions import parser
+    from gempython.vfatqc.qcoptions import parser
     
     import os, sys
     
@@ -49,7 +49,7 @@ if __name__ == '__main__':
     isCurrentPulse = (not options.voltageStepPulse)
 
     # Setup the output TTree
-    from ...vfatqc.treeStructure import gemTreeStructure
+    from gempython.vfatqc.treeStructure import gemTreeStructure
     gemData = gemTreeStructure('scurveTree','Tree Holding CMS GEM SCurve Data',scanmode.SCURVE)
     gemData.setDefaults(options, int(time.time()))
 
@@ -57,7 +57,7 @@ if __name__ == '__main__':
     vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
 
     # Check options
-    from ...vfatqc.qcutilities import inputOptionsValid
+    from gempython.vfatqc.qcutilities import inputOptionsValid
     if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
         exit(os.EX_USAGE)
         pass

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -116,13 +116,13 @@ if __name__ == '__main__':
                 
             vthvals =  dict(map(lambda slotID: (slotID, vt2vals[slotID]-vt1vals[slotID]),range(0,24)))
         else:
-            vals = vfatBoard.readAllVFATs("CFG_CAL_PHI",   0x0)
+            vals = vfatBoard.readAllVFATs("CFG_CAL_PHI",   mask)
             calPhasevals = dict(map(lambda slotID: (slotID, bin(vals[slotID]).count("1")), range(0,24)))
         
             vals = vfatBoard.readAllVFATs("CFG_PULSE_STRETCH", mask)
             msplvals =  dict(map(lambda slotID: (slotID, vals[slotID]),range(0,24)))
             
-            vals = vfatBoard.readAllVFATs("CFG_LATENCY",    0x0)
+            vals = vfatBoard.readAllVFATs("CFG_LATENCY",    mask)
             latvals = dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
                 
             #vfatIDvals = getAllChipIDs(ohboard, options.gtx, 0x0)

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -151,7 +151,7 @@ if __name__ == '__main__':
             # Perform the scan
             if options.debug: 
                 print("Starting scan; pulseDelay: %i; L1Atime: %i; Latency: %i"%(options.pDel, options.L1Atime, options.latency))
-            rpcResp = vfatBoard.parentOH.performCalibrationScan(chan, scanReg, scanData, enableCal=True, currentPulse=isCurrentPulse[0], 
+            rpcResp = vfatBoard.parentOH.performCalibrationScan(chan, scanReg, scanData, enableCal=True, currentPulse=isCurrentPulse, 
                                                                 calSF=options.calSF, nevts=options.nevts, 
                                                                 dacMin=options.scanmin, dacMax=options.scanmax, 
                                                                 stepSize=options.stepSize, mask=options.vfatmask)
@@ -187,10 +187,9 @@ if __name__ == '__main__':
                         else:
                             #trimDAC = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_AMPLITUDE"%(chan)))
                             #trimPolarity = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_POLARITY"%(chan)))
-                            vcal[0] = options.scanmin + (vcalDAC - vfat*scanDataSizeVFAT) * options.stepSize
-                            Nhits[0] = (scanData[vcalDAC]>>16) & 0xffff
                             gemData.fill(
                                     calPhase = calPhasevals[vfat],
+                                    isCurrentPulse = isCurrentPulse,
                                     l1aTime = options.L1Atime,
                                     latency = latvals[vfat],
                                     mspl = msplvals[vfat],
@@ -213,7 +212,7 @@ if __name__ == '__main__':
                     finally:
                         if options.debug:
                             print "vfat%i; vcal %i; Nev %i; Nhits %i"%(
-                                    gemData.vfat[0],
+                                    gemData.vfatN[0],
                                     gemData.vcal[0],
                                     gemData.Nev[0],
                                     gemData.Nhits[0])

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
 
     # Check options
     from gempython.vfatqc.qcutilities import inputOptionsValid
-    if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
+    if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC.fwVersion):
         exit(os.EX_USAGE)
         pass
     if options.scanmin not in range(256) or options.scanmax not in range(256) or not (options.scanmax > options.scanmin):
@@ -93,7 +93,7 @@ if __name__ == '__main__':
         vfatBoard.setVFATMSPLAll(mask, options.MSPL, options.debug)
         vfatBoard.setVFATCalPhaseAll(mask, 0xff >> (8 - options.CalPhase), options.debug)
    
-        if vfatBoard.parentOH.parentAMC < 3:
+        if vfatBoard.parentOH.parentAMC.fwVersion < 3:
             vals = vfatBoard.readAllVFATs("CalPhase",   0x0)
             calPhasevals = dict(map(lambda slotID: (slotID, bin(vals[slotID]).count("1")), range(0,24)))
                 

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -93,35 +93,35 @@ if __name__ == '__main__':
         vfatBoard.setVFATCalPhaseAll(mask, 0xff >> (8 - options.CalPhase), options.debug)
    
         if vfatBoard.parentOH.parentAMC < 3:
-            vals = readAllVFATs(ohboard, options.gtx, "CalPhase",   0x0)
+            vals = vfatBoard.readAllVFATs("CalPhase",   0x0)
             calPhasevals = dict(map(lambda slotID: (slotID, bin(vals[slotID]).count("1")), range(0,24)))
                 
-            vals = readAllVFATs(ohboard, options.gtx, "ContReg2",    0x0)
+            vals = vfatBoard.readAllVFATs("ContReg2",    0x0)
             msplvals =  dict(map(lambda slotID: (slotID, (1+(vals[slotID]>>4)&0x7)),range(0,24)))
                 
-            vals = readAllVFATs(ohboard, options.gtx, "ContReg3",    0x0)
+            vals = vfatBoard.readAllVFATs("ContReg3",    0x0)
             trimRangevals = dict(map(lambda slotID: (slotID, (0x07 & vals[slotID])),range(0,24)))
                 
-            vals = readAllVFATs(ohboard, options.gtx, "Latency",    0x0)
+            vals = vfatBoard.readAllVFATs("Latency",    0x0)
             latvals = dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
                 
-            vfatIDvals = getAllChipIDs(ohboard, options.gtx, 0x0)
+            #vfatIDvals = getAllChipIDs(ohboard, options.gtx, 0x0)
             
-            vals  = readAllVFATs(ohboard, options.gtx, "VThreshold1", 0x0)
+            vals  = vfatBoard.readAllVFATs("VThreshold1", 0x0)
             vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
                 
-            vals  = readAllVFATs(ohboard, options.gtx, "VThreshold2", 0x0)
+            vals  = vfatBoard.readAllVFATs("VThreshold2", 0x0)
             vt2vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
                 
             vthvals =  dict(map(lambda slotID: (slotID, vt2vals[slotID]-vt1vals[slotID]),range(0,24)))
         else:
-            vals = readAllVFATs(ohboard, options.gtx, "CFG_CAL_PHI",   0x0)
+            vals = vfatBoard.readAllVFATs("CFG_CAL_PHI",   0x0)
             calPhasevals = dict(map(lambda slotID: (slotID, bin(vals[slotID]).count("1")), range(0,24)))
         
             vals = vfatBoard.readAllVFATs("CFG_PULSE_STRETCH", mask)
             msplvals =  dict(map(lambda slotID: (slotID, vals[slotID]),range(0,24)))
             
-            vals = readAllVFATs(ohboard, options.gtx, "CFG_LATENCY",    0x0)
+            vals = vfatBoard.readAllVFATs("CFG_LATENCY",    0x0)
             latvals = dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
                 
             #vfatIDvals = getAllChipIDs(ohboard, options.gtx, 0x0)
@@ -176,7 +176,7 @@ if __name__ == '__main__':
                                     trimRange = trimRangevals[vfat],
                                     vcal = int((scanData[vcalDAC] & 0xff000000) >> 24),
                                     vfatCH = chan,
-                                    vfatID = vfatIDvals[vfat],
+                                    #vfatID = vfatIDvals[vfat],
                                     vfatN = vfat,
                                     vth = vthvals[vfat],
                                     vth1 = vt1vals[vfat],
@@ -209,8 +209,6 @@ if __name__ == '__main__':
                     except IndexError:
                         print 'Unable to index data for channel %i'%chan
                         print scanData[vcalDAC]
-                        vcal[0]  = -99
-                        Nhits[0] = -99
                     finally:
                         if options.debug:
                             print "vfat%i; vcal %i; Nev %i; Nhits %i"%(

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -164,7 +164,7 @@ if __name__ == '__main__':
                 for vcalDAC in range(vfat*scanDataSizeVFAT,(vfat+1)*scanDataSizeVFAT):
                     try:
                         if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-                            trimDAC = (0x1f & vfatBoard.readVFAT(vfat,"VFATChannels.ChanReg%d"%(chan)))
+                            #trimDAC = (0x1f & vfatBoard.readVFAT(vfat,"VFATChannels.ChanReg%d"%(chan)))
                             gemData.fill(
                                     calPhase = calPhasevals[vfat],
                                     l1aTime = options.L1Atime,
@@ -173,7 +173,7 @@ if __name__ == '__main__':
                                     Nev = options.nevts,
                                     Nhits = int(scanData[vcalDAC] & 0xffffff), 
                                     pDel = options.pDel,
-                                    trimDAC = trimDAC,
+                                    #trimDAC = trimDAC,
                                     trimRange = trimRangevals[vfat],
                                     vcal = int((scanData[vcalDAC] & 0xff000000) >> 24),
                                     vfatCH = chan,
@@ -185,8 +185,8 @@ if __name__ == '__main__':
                                     vthr = vt1vals[vfat]
                                     )
                         else:
-                            trimDAC = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_AMPLITUDE"%(chan)))
-                            trimPolarity = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_POLARITY"%(chan)))
+                            #trimDAC = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_AMPLITUDE"%(chan)))
+                            #trimPolarity = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_POLARITY"%(chan)))
                             vcal[0] = options.scanmin + (vcalDAC - vfat*scanDataSizeVFAT) * options.stepSize
                             Nhits[0] = (scanData[vcalDAC]>>16) & 0xffff
                             gemData.fill(
@@ -197,8 +197,8 @@ if __name__ == '__main__':
                                     Nev = (scanData[vcalDAC] & 0xffff),
                                     Nhits = ((scanData[vcalDAC]>>16) & 0xffff),
                                     pDel = options.pDel,
-                                    trimDAC = trimDAC,
-                                    trimPolarity = trimPolarity,
+                                    #trimDAC = trimDAC,
+                                    #trimPolarity = trimPolarity,
                                     vcal = (options.scanmin + (vcalDAC - vfat*scanDataSizeVFAT) * options.stepSize),
                                     vfatCH = chan,
                                     #vfatID = vfatIDvals[vfat],

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -1,238 +1,235 @@
 #!/bin/env python
-"""
-Script to take Scurve data using OH ultra scans
-By: Cameron Bravo (c.bravo@cern.ch) and Brian Dorney (brian.l.dorney@cern.ch)
-"""
 
-from array import array
-from ctypes import *
-from gempython.tools.vfat_user_functions_xhal import *
+if __name__ == '__main__':
+    """
+    Script to take Scurve data using OH ultra scans
+    By: Cameron Bravo (c.bravo@cern.ch) and Brian Dorney (brian.l.dorney@cern.ch)
+    """
+    
+    from array import array
+    from ctypes import *
+    from ...tools.vfat_user_functions_xhal import *
+    
+    from ...vfatqc.qcoptions import parser
+    
+    import os, sys
+    
+    parser.add_option("--CalPhase", type="int", dest = "CalPhase", default = 0,
+                      help="Specify CalPhase. Must be in range 0-8", metavar="CalPhase")
+    parser.add_option("--calSF", type="int", dest = "calSF", default = 0,
+                      help="V3 electroncis only. Value of the CFG_CAL_FS register", metavar="calSF")
+    parser.add_option("--chMin", type="int", dest = "chMin", default = 0,
+                      help="Specify minimum channel number to scan", metavar="chMin")
+    parser.add_option("--chMax", type="int", dest = "chMax", default = 127,
+                      help="Specify maximum channel number to scan", metavar="chMax")
+    parser.add_option("-f", "--filename", type="string", dest="filename", default="SCurveData.root",
+                      help="Specify Output Filename", metavar="filename")
+    parser.add_option("--latency", type="int", dest = "latency", default = 37,
+                      help="Specify Latency", metavar="latency")
+    parser.add_option("--voltageStepPulse", action="store_true",dest="voltageStepPulse", 
+                      help="V3 electronics only. Calibration Module is set to use voltage step pulsing instead of default current pulse injection", 
+                      metavar="voltageStepPulse")
+    (options, args) = parser.parse_args()
+    
+    remainder = (options.scanmax-options.scanmin+1) % options.stepSize
+    if remainder != 0:
+        options.scanmax = options.scanmax + remainder
+        print "extending scanmax to: ", options.scanmax
+    
+    import ROOT as r
+    filename = options.filename
+    myF = r.TFile(filename,'recreate')
+    
+    import subprocess,datetime,time
+    startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
+    print startTime
+    Date = startTime
 
-from gempython.vfatqc.qcoptions import parser
+    # Track the current pulse
+    isCurrentPulse = (not options.voltageStepPulse)
 
-import os, sys
+    # Setup the output TTree
+    from ...vfatqc.treeStructure import gemTreeStructure
+    gemData = gemTreeStructure('scurveTree','Tree Holding CMS GEM SCurve Data',scanmode.SCURVE)
+    gemData.setDefaults(options, int(time.time()))
 
-parser.add_option("--CalPhase", type="int", dest = "CalPhase", default = 0,
-                  help="Specify CalPhase. Must be in range 0-8", metavar="CalPhase")
-parser.add_option("--calSF", type="int", dest = "calSF", default = 0,
-                  help="V3 electroncis only. Value of the CFG_CAL_FS register", metavar="calSF")
-parser.add_option("--chMin", type="int", dest = "chMin", default = 0,
-                  help="Specify minimum channel number to scan", metavar="chMin")
-parser.add_option("--chMax", type="int", dest = "chMax", default = 127,
-                  help="Specify maximum channel number to scan", metavar="chMax")
-parser.add_option("-f", "--filename", type="string", dest="filename", default="SCurveData.root",
-                  help="Specify Output Filename", metavar="filename")
-parser.add_option("--latency", type="int", dest = "latency", default = 37,
-                  help="Specify Latency", metavar="latency")
-parser.add_option("--voltageStepPulse", action="store_true",dest="voltageStepPulse", 
-                  help="V3 electronics only. Calibration Module is set to use voltage step pulsing instead of default current pulse injection", 
-                  metavar="voltageStepPulse")
+    # Open rpc connection to hw
+    vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
 
-(options, args) = parser.parse_args()
-
-if options.MSPL < 1 or options.MSPL > 8:
-    print 'MSPL must be in the range 1-8'
-    exit(os.EX_USAGE)
-    pass
-if not (0 <= options.chMin <= options.chMax < 128):
-    print "chMin %d not in [0,%d] or chMax %d not in [%d,127] or chMax < chMin"%(options.chMin,options.chMax,options.chMax,options.chMin)
-    exit(os.EX_USAGE)
-    pass
-
-if options.calSF < 0 or options.calSF > 3:
-    print 'calSF must be in the range 0-3'
-    exit(os.EX_USAGE)
-    pass
-
-remainder = (options.scanmax-options.scanmin+1) % options.stepSize
-if remainder != 0:
-    options.scanmax = options.scanmax + remainder
-    print "extending scanmax to: ", options.scanmax
-
-import ROOT as r
-filename = options.filename
-myF = r.TFile(filename,'recreate')
-myT = r.TTree('scurveTree','Tree Holding CMS GEM SCurve Data')
-
-Nev = array( 'i', [ 0 ] )
-Nev[0] = -1
-myT.Branch( 'Nev', Nev, 'Nev/I' )
-
-vcal = array( 'i', [ 0 ] )
-myT.Branch( 'vcal', vcal, 'vcal/I' )
-
-Nhits = array( 'i', [ 0 ] )
-myT.Branch( 'Nhits', Nhits, 'Nhits/I' )
-
-vfatN = array( 'i', [ 0 ] )
-myT.Branch( 'vfatN', vfatN, 'vfatN/I' )
-
-vfatCH = array( 'i', [ 0 ] )
-myT.Branch( 'vfatCH', vfatCH, 'vfatCH/I' )
-
-trimRange = array( 'i', [ 0 ] )
-myT.Branch( 'trimRange', trimRange, 'trimRange/I' )
-
-vthr = array( 'i', [ 0 ] )
-myT.Branch( 'vthr', vthr, 'vthr/I' )
-
-trimDAC = array( 'i', [ 0 ] )
-myT.Branch( 'trimDAC', trimDAC, 'trimDAC/I' )
-
-l1aTime = array( 'i', [ 0 ] )
-myT.Branch( 'l1aTime', l1aTime, 'l1aTime/I' )
-l1aTime[0] = options.L1Atime
-
-mspl = array( 'i', [ 0 ] )
-myT.Branch( 'mspl', mspl, 'mspl/I' )
-mspl[0] = options.MSPL
-
-latency = array( 'i', [ 0 ] )
-myT.Branch( 'latency', latency, 'latency/I' )
-latency[0] = options.latency
-
-pDel = array( 'i', [ 0 ] )
-myT.Branch( 'pDel', pDel, 'pDel/I' )
-pDel[0] = options.pDel
-
-calPhase = array( 'i', [ 0 ] )
-myT.Branch( 'calPhase', calPhase, 'calPhase/I' )
-calPhase[0] = options.CalPhase
-
-calSF = array( 'i', [0] )
-myT.Branch( 'calSF', calSF, 'calSF/I')
-calSF[0] = options.calSF
-
-isCurrentPulse = array( 'i', [ 0 ] )
-myT.Branch( 'isCurrentPulse', isCurrentPulse, 'isCurrentPulse/I')
-isCurrentPulse[0] = not options.voltageStepPulse
-
-link = array( 'i', [ 0 ] )
-myT.Branch( 'link', link, 'link/I' )
-link[0] = options.gtx
-
-utime = array( 'i', [ 0 ] )
-myT.Branch( 'utime', utime, 'utime/I' )
-
-import subprocess,datetime,time
-startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
-print startTime
-Date = startTime
-
-vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
-
-if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-    if options.CalPhase < 0 or options.CalPhase > 8:
-        print 'CalPhase must be in the range 0-8'
+    # Check options
+    from ...vfatqc.qcutilities import inputOptionsValid
+    if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
         exit(os.EX_USAGE)
         pass
-else:
-    if options.CalPhase < 0 or options.CalPhase > 7:
-        print 'CalPhase must be in the range 0-7'
-        exit(os.EX_USAGE)
+    if options.scanmin not in range(256) or options.scanmax not in range(256) or not (options.scanmax > options.scanmin):
+        print("Invalid scan parameters specified [min,max] = [%d,%d]"%(options.scanmin,options.scanmax))
+        print("Scan parameters must be in range [0,255] and min < max")
+        exit(1)
         pass
 
-CHAN_MIN = options.chMin
-CHAN_MAX = options.chMax + 1
-#if options.debug:
-#    CHAN_MAX = 5
-#    pass
-
-mask = options.vfatmask
-
-try:
-    # Set Trigger Source for v2b electronics
-    print "setting trigger source"
-    if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-        vfatBoard.parentOH.setTriggerSource(0x1)
-        print("OH%i: Trigger Source %i"%(vfatBoard.parentOH.link,vfatBoard.parentOH.getTriggerSource()))
-
-    # Configure TTC
-    print "attempting to configure TTC"
-    if 0 == vfatBoard.parentOH.parentAMC.configureTTC(options.pDel,options.L1Atime,options.gtx,1,0,0,True):
-        print "TTC configured successfully"
-        vfatBoard.parentOH.parentAMC.getTTCStatus(options.gtx,True)
-    else:
-        raise Exception('RPC response was non-zero, TTC configuration failed')
-
-    vfatBoard.setVFATLatencyAll(mask=options.vfatmask, lat=options.latency, debug=options.debug)
-    vfatBoard.setRunModeAll(mask, True, options.debug)
-    vfatBoard.setVFATMSPLAll(mask, options.MSPL, options.debug)
-    vfatBoard.setVFATCalPhaseAll(mask, 0xff >> (8 - options.CalPhase), options.debug)
-
-    # Make sure no channels are receiving a cal pulse
-    # This needs to be done on the CTP7 otherwise it takes an hour...
-    print "stopping cal pulse to all channels"
-    vfatBoard.stopCalPulses(mask, CHAN_MIN, CHAN_MAX)
-
-    scanDataSizeVFAT = (options.scanmax-options.scanmin+1)/options.stepSize
-    scanDataSizeNet = scanDataSizeVFAT * 24
-    scanData = (c_uint32 * scanDataSizeNet)()
-    for chan in range(CHAN_MIN,CHAN_MAX):
-        vfatCH[0] = chan
-        print "Channel #"+str(chan)
-        
-        # Determine the scanReg
-        scanReg = "CAL_DAC"
+    CHAN_MIN = options.chMin
+    CHAN_MAX = options.chMax + 1
+    
+    mask = options.vfatmask
+    
+    try:
+        # Set Trigger Source for v2b electronics
+        print "setting trigger source"
         if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-            scanReg = "VCal"
+            vfatBoard.parentOH.setTriggerSource(0x1)
+            print("OH%i: Trigger Source %i"%(vfatBoard.parentOH.link,vfatBoard.parentOH.getTriggerSource()))
+    
+        # Configure TTC
+        print "attempting to configure TTC"
+        if 0 == vfatBoard.parentOH.parentAMC.configureTTC(options.pDel,options.L1Atime,options.gtx,1,0,0,True):
+            print "TTC configured successfully"
+            vfatBoard.parentOH.parentAMC.getTTCStatus(options.gtx,True)
+        else:
+            raise Exception('RPC response was non-zero, TTC configuration failed')
+    
+        vfatBoard.setVFATLatencyAll(mask=options.vfatmask, lat=options.latency, debug=options.debug)
+        vfatBoard.setRunModeAll(mask, True, options.debug)
+        vfatBoard.setVFATMSPLAll(mask, options.MSPL, options.debug)
+        vfatBoard.setVFATCalPhaseAll(mask, 0xff >> (8 - options.CalPhase), options.debug)
+   
+        if vfatBoard.parentOH.parentAMC < 3:
+            vals = readAllVFATs(ohboard, options.gtx, "CalPhase",   0x0)
+            calPhasevals = dict(map(lambda slotID: (slotID, bin(vals[slotID]).count("1")), range(0,24)))
+                
+            vals = readAllVFATs(ohboard, options.gtx, "ContReg2",    0x0)
+            msplvals =  dict(map(lambda slotID: (slotID, (1+(vals[slotID]>>4)&0x7)),range(0,24)))
+                
+            vals = readAllVFATs(ohboard, options.gtx, "ContReg3",    0x0)
+            trimRangevals = dict(map(lambda slotID: (slotID, (0x07 & vals[slotID])),range(0,24)))
+                
+            vals = readAllVFATs(ohboard, options.gtx, "Latency",    0x0)
+            latvals = dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
+                
+            vfatIDvals = getAllChipIDs(ohboard, options.gtx, 0x0)
             
-        # Perform the scan
-        if options.debug: 
-            print("Starting scan; pulseDelay: %i; L1Atime: %i; Latency: %i"%(options.pDel, options.L1Atime, options.latency))
-        rpcResp = vfatBoard.parentOH.performCalibrationScan(chan, scanReg, scanData, enableCal=True, currentPulse=isCurrentPulse[0], 
-                                                            calSF=options.calSF, nevts=options.nevts, 
-                                                            dacMin=options.scanmin, dacMax=options.scanmax, 
-                                                            stepSize=options.stepSize, mask=options.vfatmask)
-
-        if rpcResp != 0:
-            raise Exception('RPC response was non-zero, scurve for channel %i failed'%chan)
+            vals  = readAllVFATs(ohboard, options.gtx, "VThreshold1", 0x0)
+            vt1vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
+                
+            vals  = readAllVFATs(ohboard, options.gtx, "VThreshold2", 0x0)
+            vt2vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
+                
+            vthvals =  dict(map(lambda slotID: (slotID, vt2vals[slotID]-vt1vals[slotID]),range(0,24)))
+        else:
+            vals = readAllVFATs(ohboard, options.gtx, "CFG_CAL_PHI",   0x0)
+            calPhasevals = dict(map(lambda slotID: (slotID, bin(vals[slotID]).count("1")), range(0,24)))
         
-        for vfat in range(0,24):
-            if (mask >> vfat) & 0x1: continue
-            vfatN[0] = vfat
-            if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-                isCurrentPulse[0]   = not options.voltageStepPulse
-                trimRange[0]        = (0x07 & vfatBoard.readVFAT(vfat,"ContReg3"))
-                trimDAC[0]          = (0x1f & vfatBoard.readVFAT(vfat,"VFATChannels.ChanReg%d"%(chan)))
-                vthr[0]             = (0xff & vfatBoard.readVFAT(vfat,"VThreshold1"))
-            else:
-                trimDAC[0]   = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_AMPLITUDE"%(chan)))
-                vthr[0]      = (0xff & vfatBoard.readVFAT(vfat,"CFG_THR_ARM_DAC"))
+            vals = vfatBoard.readAllVFATs("CFG_PULSE_STRETCH", mask)
+            msplvals =  dict(map(lambda slotID: (slotID, vals[slotID]),range(0,24)))
             
-            for vcalDAC in range(vfat*scanDataSizeVFAT,(vfat+1)*scanDataSizeVFAT):
-                try:
-                    # Set Nev, Nhits & vcal
-                    if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-                        vcal[0]  = int((scanData[vcalDAC] & 0xff000000) >> 24)
-                        Nev[0] = options.nevts
-                        Nhits[0] = int(scanData[vcalDAC] & 0xffffff)
-                    else:
-                        #if vfat == 0:
-                        #    vcal[0] = scanDataSizeVFAT - vcalDAC
-                        #else:
-                        #    vcal[0] = (vfat+1)*scanDataSizeVFAT - vcalDAC
-                        vcal[0] = options.scanmin + (vcalDAC - vfat*scanDataSizeVFAT) * options.stepSize
-                        Nev[0] = scanData[vcalDAC] & 0xffff
-                        Nhits[0] = (scanData[vcalDAC]>>16) & 0xffff
-                except IndexError:
-                    print 'Unable to index data for channel %i'%chan
-                    print scanData[vcalDAC]
-                    vcal[0]  = -99
-                    Nhits[0] = -99
-                finally:
-                    if options.debug:
-                        print "vfat%i; vcal %i; Nev %i; Nhits %i"%(vfatN[0],vcal[0],Nev[0],Nhits[0])
-                    myT.Fill()
-        myT.AutoSave("SaveSelf")
-        sys.stdout.flush()
-        pass
-    vfatBoard.parentOH.parentAMC.toggleTTCGen(options.gtx, False)
-    vfatBoard.setRunModeAll(mask, False, options.debug)
-except Exception as e:
-    gemData.autoSave()
-    print "An exception occurred", e
-finally:
-    myF.cd()
-    gemData.write()
-    myF.Close()
+            vals = readAllVFATs(ohboard, options.gtx, "CFG_LATENCY",    0x0)
+            latvals = dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
+                
+            #vfatIDvals = getAllChipIDs(ohboard, options.gtx, 0x0)
+            
+            vals  = vfatBoard.readAllVFATs("CFG_THR_ARM_DAC", mask)
+            vthrvals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
+            
+            pass
+
+        # Make sure no channels are receiving a cal pulse
+        # This needs to be done on the CTP7 otherwise it takes an hour...
+        print "stopping cal pulse to all channels"
+        vfatBoard.stopCalPulses(mask, CHAN_MIN, CHAN_MAX)
+    
+        scanDataSizeVFAT = (options.scanmax-options.scanmin+1)/options.stepSize
+        scanDataSizeNet = scanDataSizeVFAT * 24
+        scanData = (c_uint32 * scanDataSizeNet)()
+        for chan in range(CHAN_MIN,CHAN_MAX):
+            print "Channel #"+str(chan)
+            
+            # Determine the scanReg
+            scanReg = "CAL_DAC"
+            if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+                scanReg = "VCal"
+                
+            # Perform the scan
+            if options.debug: 
+                print("Starting scan; pulseDelay: %i; L1Atime: %i; Latency: %i"%(options.pDel, options.L1Atime, options.latency))
+            rpcResp = vfatBoard.parentOH.performCalibrationScan(chan, scanReg, scanData, enableCal=True, currentPulse=isCurrentPulse[0], 
+                                                                calSF=options.calSF, nevts=options.nevts, 
+                                                                dacMin=options.scanmin, dacMax=options.scanmax, 
+                                                                stepSize=options.stepSize, mask=options.vfatmask)
+    
+            if rpcResp != 0:
+                raise Exception('RPC response was non-zero, scurve for channel %i failed'%chan)
+            
+            for vfat in range(0,24):
+                if (mask >> vfat) & 0x1: continue
+                for vcalDAC in range(vfat*scanDataSizeVFAT,(vfat+1)*scanDataSizeVFAT):
+                    try:
+                        if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+                            trimDAC = (0x1f & vfatBoard.readVFAT(vfat,"VFATChannels.ChanReg%d"%(chan)))
+                            gemData.fill(
+                                    calPhase = calPhasevals[vfat],
+                                    l1aTime = options.L1Atime,
+                                    latency = latvals[vfat],
+                                    mspl = msplvals[vfat],
+                                    Nev = options.nevts,
+                                    Nhits = int(scanData[vcalDAC] & 0xffffff), 
+                                    pDel = options.pDel,
+                                    trimDAC = trimDAC,
+                                    trimRange = trimRangevals[vfat],
+                                    vcal = int((scanData[vcalDAC] & 0xff000000) >> 24),
+                                    vfatCH = chan,
+                                    vfatID = vfatIDvals[vfat],
+                                    vfatN = vfat,
+                                    vth = vthvals[vfat],
+                                    vth1 = vt1vals[vfat],
+                                    vth2 = vt2vals[vfat],
+                                    vthr = vt1vals[vfat]
+                                    )
+                        else:
+                            trimDAC = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_AMPLITUDE"%(chan)))
+                            trimPolarity = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_POLARITY"%(chan)))
+                            vcal[0] = options.scanmin + (vcalDAC - vfat*scanDataSizeVFAT) * options.stepSize
+                            Nhits[0] = (scanData[vcalDAC]>>16) & 0xffff
+                            gemData.fill(
+                                    calPhase = calPhasevals[vfat],
+                                    l1aTime = options.L1Atime,
+                                    latency = latvals[vfat],
+                                    mspl = msplvals[vfat],
+                                    Nev = (scanData[vcalDAC] & 0xffff),
+                                    Nhits = ((scanData[vcalDAC]>>16) & 0xffff),
+                                    pDel = options.pDel,
+                                    trimDAC = trimDAC,
+                                    trimPolarity = trimPolarity,
+                                    vcal = (options.scanmin + (vcalDAC - vfat*scanDataSizeVFAT) * options.stepSize),
+                                    vfatCH = chan,
+                                    #vfatID = vfatIDvals[vfat],
+                                    vfatN = vfat,
+                                    vthr = vthrvals[vfat]
+                                    )
+                            pass
+
+                    except IndexError:
+                        print 'Unable to index data for channel %i'%chan
+                        print scanData[vcalDAC]
+                        vcal[0]  = -99
+                        Nhits[0] = -99
+                    finally:
+                        if options.debug:
+                            print "vfat%i; vcal %i; Nev %i; Nhits %i"%(
+                                    gemData.vfat[0],
+                                    gemData.vcal[0],
+                                    gemData.Nev[0],
+                                    gemData.Nhits[0])
+                            pass
+                        pass
+            gemData.autoSave("SaveSelf")
+            sys.stdout.flush()
+            pass
+        
+        vfatBoard.parentOH.parentAMC.toggleTTCGen(options.gtx, False)
+        vfatBoard.setRunModeAll(mask, False, options.debug)
+    except Exception as e:
+        gemData.autoSave()
+        print "An exception occurred", e
+    finally:
+        myF.cd()
+        gemData.write()
+        myF.Close()

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -1,305 +1,360 @@
 #!/bin/env python
-"""
-Script to take VT1 data using OH ultra scans
-By: Cameron Bravo (c.bravo@cern.ch)
-    Jared Sturdy  (sturdy@cern.ch)
-    Brian Dorney (brian.l.dorney@cern.ch)
-"""
 
-import sys, os, random, time
-from array import array
-from ctypes import *
-
-from gempython.tools.vfat_user_functions_xhal import *
-
-from gempython.vfatqc.qcoptions import parser
-
-parser.add_option("--chMin", type="int", dest = "chMin", default = 0,
-                  help="Specify minimum channel number to scan", metavar="chMin")
-parser.add_option("--chMax", type="int", dest = "chMax", default = 127,
-                  help="Specify maximum channel number to scan", metavar="chMax")
-parser.add_option("-f", "--filename", type="string", dest="filename", default="VThreshold1Data_Trimmed.root",
-                  help="Specify Output Filename", metavar="filename")
-parser.add_option("--perchannel", action="store_true", dest="perchannel",
-                  help="Run a per-channel VT1 scan", metavar="perchannel")
-parser.add_option("--trkdata", action="store_true", dest="trkdata",
-                  help="Run a per-VFAT VT1 scan using tracking data (default is to use trigger data)", metavar="trkdata")
-parser.add_option("--vt2", type="int", dest="vt2", default=0,
-                  help="Specify VT2 to use", metavar="vt2")
-parser.add_option("--zcc", action="store_true", dest="scanZCC",
-                  help="V3 Electronics only, scan the threshold on the ZCC instead of the ARM comparator", metavar="scanZCC")
-
-(options, args) = parser.parse_args()
-
-remainder = (options.scanmax-options.scanmin+1) % options.stepSize
-if remainder != 0:
-    options.scanmax = options.scanmax + remainder
-    print "extending scanmax to: ", options.scanmax
-
-import ROOT as r
-filename = options.filename
-myF = r.TFile(filename,'recreate')
-myT = r.TTree('thrTree','Tree Holding CMS GEM VT1 Data')
-
-isZCC = array( 'i', [0] )
-myT.Branch( 'isZCC', isZCC, 'isZCC/I' )
-Nev = array( 'i', [ 0 ] )
-Nev[0] = -1
-myT.Branch( 'Nev', Nev, 'Nev/I' )
-vth = array( 'i', [ 0 ] )
-myT.Branch( 'vth', vth, 'vth/I' )
-vth1 = array( 'i', [ 0 ] )
-myT.Branch( 'vth1', vth1, 'vth1/I' )
-vth2 = array( 'i', [ 0 ] )
-myT.Branch( 'vth2', vth2, 'vth2/I' )
-vth2[0] = options.vt2
-Nhits = array( 'i', [ 0 ] )
-myT.Branch( 'Nhits', Nhits, 'Nhits/I' )
-vfatN = array( 'i', [ 0 ] )
-myT.Branch( 'vfatN', vfatN, 'vfatN/I' )
-vfatCH = array( 'i', [ 0 ] )
-myT.Branch( 'vfatCH', vfatCH, 'vfatCH/I' )
-trimRange = array( 'i', [ 0 ] )
-myT.Branch( 'trimRange', trimRange, 'trimRange/I' )
-link = array( 'i', [ 0 ] )
-myT.Branch( 'link', link, 'link/I' )
-link[0] = options.gtx
-mode = array( 'i', [ 0 ] )
-myT.Branch( 'mode', mode, 'mode/I' )
-utime = array( 'i', [ 0 ] )
-myT.Branch( 'utime', utime, 'utime/I' )
-
-import subprocess,datetime,time
-startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
-print startTime
-Date = startTime
-
-# Open rpc connection to hw
-vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
-
-# Check options
-from gempython.vfatqc.qcutilities import inputOptionsValid
-if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
-    exit(os.EX_USAGE)
-    pass
-if options.scanmin not in range(256) or options.scanmax not in range(256) or not (options.scanmax > options.scanmin):
-    print("Invalid scan parameters specified [min,max] = [%d,%d]"%(options.scanmin,options.scanmax))
-    print("Scan parameters must be in range [0,255] and min < max")
-    exit(1)
-    pass
-
-CHAN_MIN = options.chMin
-CHAN_MAX = options.chMax + 1
-if options.debug:
-    CHAN_MAX = 5
-    pass
-
-mask = options.vfatmask
-
-try:
-    vfatBoard.setVFATLatencyAll(mask=options.vfatmask, lat=0, debug=options.debug)
-    vfatBoard.setRunModeAll(mask, True, options.debug)
-    vfatBoard.setVFATThresholdAll(mask=options.vfatmask, vt1=100, vt2=options.vt2, debug=options.debug)
-
-    if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-        print "getting trigger source"
-        trgSrc = vfatBoard.parentOH.getTriggerSource()
-            
-    scanReg = "THR_ARM_DAC"
-    if vfatBoard.parentOH.parentAMC.fwVersion >= 3:
-        #Store original CFG_SEL_COMP_MODE
-        vals  = vfatBoard.readAllVFATs("CFG_SEL_COMP_MODE", mask)
-        selCompVals_orig =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
-            range(0,24)))
-
-        #Store original CFG_FORCE_EN_ZCC
-        vals = vfatBoard.readAllVFATs("CFG_FORCE_EN_ZCC", mask)
-        forceEnZCCVals_orig =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
-            range(0,24)))
-
-        if options.scanZCC:
-            isZCC[0] = 1
-
-            #Reset scanReg
-            scanReg = "THR_ZCC_DAC"
-            
-            print "Setting CFG_SEL_COMP_MODE to 0x2 (ZCC Mode)"
-            vfatBoard.writeAllVFATs("CFG_SEL_COMP_MODE", 0x2, mask)
-            vals  = vfatBoard.readAllVFATs("CFG_SEL_COMP_MODE", mask)
-            selCompVals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
-                range(0,24)))
-
-            print "Forcing the ZCC output to be enabled independent of the ARM comparator"
-            vfatBoard.writeAllVFATs("CFG_FORCE_EN_ZCC", 0x1, mask)
-            vals = vfatBoard.readAllVFATs("CFG_FORCE_EN_ZCC", mask)
-            forceEnZCCVals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
-                range(0,24)))
-        else:
-            print "Setting CFG_SEL_COMP_MODE to 0x1 (ARM Mode)"
-            vfatBoard.writeAllVFATs("CFG_SEL_COMP_MODE", 0x1, mask)
-            vals  = vfatBoard.readAllVFATs("CFG_SEL_COMP_MODE", mask)
-            selCompVals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
-                range(0,24)))
-
-            print "Do not force ZCC output"
-            vfatBoard.writeAllVFATs("CFG_FORCE_EN_ZCC", 0x0, mask)
-            vals = vfatBoard.readAllVFATs("CFG_FORCE_EN_ZCC", mask)
-            forceEnZCCVals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
-                range(0,24)))
-            
-
-    if options.perchannel: 
-        # Set Trigger Source for v2b electronics
-        if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-            print "setting trigger source"
-            vfatBoard.parentOH.setTriggerSource(0x1)
-       
-       # Configure TTC
-        print "attempting to configure TTC"
-        if 0 == vfatBoard.parentOH.parentAMC.configureTTC(pulseDelay=0,L1Ainterval=250,ohN=options.gtx,enable=True):
-            print "TTC configured successfully"
-        else:
-            raise Exception('RPC response was non-zero, TTC configuration failed')
+if __name__ == '__main__':
+    """
+    Script to take VT1 data using OH ultra scans
+    By: Cameron Bravo (c.bravo@cern.ch)
+        Jared Sturdy  (sturdy@cern.ch)
+        Brian Dorney (brian.l.dorney@cern.ch)
+    """
     
-        scanDataSizeVFAT = (options.scanmax-options.scanmin+1)/options.stepSize
-        scanDataSizeNet = scanDataSizeVFAT * 24
-        scanData = (c_uint32 * scanDataSizeNet)()
-        for chan in range(CHAN_MIN,CHAN_MAX):
-            vfatCH[0] = chan
-            print "Channel #"+str(chan)
-        
-            # Reset scanReg if needed
-            if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-                scanReg = "VThreshold1PerChan"
+    import sys, os, random, time
+    from array import array
+    from ctypes import *
+    
+    from gempython.tools.vfat_user_functions_xhal import *
+    
+    from gempython.vfatqc.qcoptions import parser
+    
+    parser.add_option("--chMin", type="int", dest = "chMin", default = 0,
+                      help="Specify minimum channel number to scan", metavar="chMin")
+    parser.add_option("--chMax", type="int", dest = "chMax", default = 127,
+                      help="Specify maximum channel number to scan", metavar="chMax")
+    parser.add_option("-f", "--filename", type="string", dest="filename", default="VThreshold1Data_Trimmed.root",
+                      help="Specify Output Filename", metavar="filename")
+    parser.add_option("--perchannel", action="store_true", dest="perchannel",
+                      help="Run a per-channel VT1 scan", metavar="perchannel")
+    parser.add_option("--trkdata", action="store_true", dest="trkdata",
+                      help="Run a per-VFAT VT1 scan using tracking data (default is to use trigger data)", metavar="trkdata")
+    parser.add_option("--vt2", type="int", dest="vt2", default=0,
+                      help="Specify VT2 to use", metavar="vt2")
+    parser.add_option("--zcc", action="store_true", dest="scanZCC",
+                      help="V3 Electronics only, scan the threshold on the ZCC instead of the ARM comparator", metavar="scanZCC")
+    
+    (options, args) = parser.parse_args()
+    
+    remainder = (options.scanmax-options.scanmin+1) % options.stepSize
+    if remainder != 0:
+        options.scanmax = options.scanmax + remainder
+        print "extending scanmax to: ", options.scanmax
+    
+    import ROOT as r
+    filename = options.filename
+    myF = r.TFile(filename,'recreate')
+    
+    import subprocess,datetime,time
+    startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
+    print startTime
+    Date = startTime
 
-            # Perform the scan
-            rpcResp = vfatBoard.parentOH.performCalibrationScan(chan, scanReg, scanData, enableCal=False, nevts=options.nevts, 
-                                                                dacMin=options.scanmin, dacMax=options.scanmax, 
-                                                                stepSize=options.stepSize, mask=options.vfatmask)
+    # Setup the output TTree
+    from gempython.vfatqc.treeStructure import gemTreeStructure
+    gemData = gemTreeStructure('thrTree','Tree Holding CMS GEM VThreshold Data')
+    gemData.setDefaults(options, int(time.time()))
 
-            if rpcResp != 0:
-                raise Exception('RPC response was non-zero, threshold scan for channel %i failed'%chan)
-            
-            sys.stdout.flush()
-            for vfat in range(0,24):
-                if (mask >> vfat) & 0x1: continue
-                vfatN[0] = vfat
-                if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-                    trimRange[0] = (0x07 & vfatBoard.readVFAT(vfat,"ContReg3"))
-                
-                for threshDAC in range(vfat*scanDataSizeVFAT,(vfat+1)*scanDataSizeVFAT):
-                    try:
-                        if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-                            vth1[0]  = int((scanData[threshDAC] & 0xff000000) >> 24)
-                            vth[0]   = vth2[0] - vth1[0]
-                            Nev[0] = options.nevts
-                            Nhits[0] = int(scanData[threshDAC] & 0xffffff)
-                        else:
-                            if vfat == 0:
-                                # what happens if we don't scan from 0 to 255?
-                                vth1[0] = threshDAC
-                            else:
-                                # what happens if we don't scan from 0 to 255?
-                                vth1[0] = threshDAC - vfat*scanDataSizeVFAT
-                            Nev[0] = scanData[threshDAC] & 0xffff
-                            Nhits[0] = (scanData[threshDAC]>>16) & 0xffff
-                    except IndexError:
-                        print 'Unable to index data for channel %i'%chan
-                        print scanData[threshDAC]
-                        vth1[0]  = -99
-                        Nhits[0] = -99
-                    finally:
-                        myT.Fill()
-                pass
-            gemData.autoSave()
-            pass
-
-        if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-            vfatBoard.parentOH.setTriggerSource(trgSrc)
-        vfatBoard.parentOH.parentAMC.toggleTTCGen(options.gtx, False)
+    # Open rpc connection to hw
+    vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
+    
+    # Check options
+    from gempython.vfatqc.qcutilities import inputOptionsValid
+    if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
+        exit(os.EX_USAGE)
         pass
-    else:
-        if not (vfatBoard.parentOH.parentAMC.fwVersion < 3):
-            print "For v3 electronics please use the --perchannel option"
-            print "Exiting"
-            sys.exit(os.EX_USAGE)
+    if options.scanmin not in range(256) or options.scanmax not in range(256) or not (options.scanmax > options.scanmin):
+        print("Invalid scan parameters specified [min,max] = [%d,%d]"%(options.scanmin,options.scanmax))
+        print("Scan parameters must be in range [0,255] and min < max")
+        exit(1)
+        pass
+    
+    CHAN_MIN = options.chMin
+    CHAN_MAX = options.chMax + 1
+    if options.debug:
+        CHAN_MAX = 5
+        pass
+    
+    mask = options.vfatmask
+    
+    try:
+        vfatBoard.setVFATLatencyAll(mask=options.vfatmask, lat=0, debug=options.debug)
+        vfatBoard.setRunModeAll(mask, True, options.debug)
+        vfatBoard.setVFATThresholdAll(mask=options.vfatmask, vt1=100, vt2=options.vt2, debug=options.debug)
+    
+        if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+            print "getting trigger source"
+            trgSrc = vfatBoard.parentOH.getTriggerSource()
+                
+        scanReg = "THR_ARM_DAC"
+        if vfatBoard.parentOH.parentAMC.fwVersion >= 3:
+            vals = vfatBoard.readAllVFATs("CFG_CAL_PHI", mask)
+            calPhasevals = dict(map(lambda slotID: (slotID, bin(vals[slotID]).count("1")), range(0,24)))
+            
+            vals = vfatBoard.readAllVFATs("CFG_PULSE_STRETCH", mask)
+            msplvals =  dict(map(lambda slotID: (slotID, vals[slotID]),range(0,24)))
+            
+            vals = vfatBoard.readAllVFATs("CFG_LATENCY", mask)
+            latvals = dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
 
-        if options.trkdata:
-            print "setting trigger source"
-            vfatBoard.parentOH.setTriggerSource(0x1)
+            #Store original CFG_SEL_COMP_MODE
+            vals  = vfatBoard.readAllVFATs("CFG_SEL_COMP_MODE", mask)
+            selCompVals_orig =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
+                range(0,24)))
+    
+            #Store original CFG_FORCE_EN_ZCC
+            vals = vfatBoard.readAllVFATs("CFG_FORCE_EN_ZCC", mask)
+            forceEnZCCVals_orig =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
+                range(0,24)))
+    
+            if options.scanZCC:
+                isZCC[0] = 1
+    
+                #Reset scanReg
+                scanReg = "THR_ZCC_DAC"
+                
+                print "Setting CFG_SEL_COMP_MODE to 0x2 (ZCC Mode)"
+                vfatBoard.writeAllVFATs("CFG_SEL_COMP_MODE", 0x2, mask)
+                vals  = vfatBoard.readAllVFATs("CFG_SEL_COMP_MODE", mask)
+                selCompVals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
+                    range(0,24)))
+    
+                print "Forcing the ZCC output to be enabled independent of the ARM comparator"
+                vfatBoard.writeAllVFATs("CFG_FORCE_EN_ZCC", 0x1, mask)
+                vals = vfatBoard.readAllVFATs("CFG_FORCE_EN_ZCC", mask)
+                forceEnZCCVals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
+                    range(0,24)))
+            else:
+                print "Setting CFG_SEL_COMP_MODE to 0x1 (ARM Mode)"
+                vfatBoard.writeAllVFATs("CFG_SEL_COMP_MODE", 0x1, mask)
+                vals  = vfatBoard.readAllVFATs("CFG_SEL_COMP_MODE", mask)
+                selCompVals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
+                    range(0,24)))
+    
+                print "Do not force ZCC output"
+                vfatBoard.writeAllVFATs("CFG_FORCE_EN_ZCC", 0x0, mask)
+                vals = vfatBoard.readAllVFATs("CFG_FORCE_EN_ZCC", mask)
+                forceEnZCCVals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
+                    range(0,24)))
+                pass
+        else:
+            vals = vfatBoard.readAllVFATs("CalPhase",   0x0)
+            calPhasevals = dict(map(lambda slotID: (slotID, bin(vals[slotID]).count("1")),range(0,24)))
             
-            scanReg = "VThreshold1Trk"
+            vals = vfatBoard.readAllVFATs("ContReg2",    0x0)    
+            msplvals =  dict(map(lambda slotID: (slotID, (1+(vals[slotID]>>4)&0x7)),range(0,24)))
+                    
+            vals = vfatBoard.readAllVFATs("ContReg3",    0x0)
+            trimRangevals = dict(map(lambda slotID: (slotID, (0x07 & vals[slotID])),range(0,24)))
+                            
+            vals = vfatBoard.readAllVFATs("Latency",    0x0)
+            latvals = dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
+                                    
+            #vfatIDvals = getAllChipIDs(ohboard, options.gtx, 0x0)
             
-            # Configure TTC
+            vals  = vfatBoard.readAllVFATs("VThreshold2", 0x0)
+            vt2vals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
+                
+            vthvals =  dict(map(lambda slotID: (slotID, vt2vals[slotID]-vt1vals[slotID]),range(0,24)))
+            pass
+    
+        if options.perchannel: 
+            gemData.mode[0] = scanmode.THRESHCH
+            
+            # Set Trigger Source for v2b electronics
+            if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+                print "setting trigger source"
+                vfatBoard.parentOH.setTriggerSource(0x1)
+
+           # Configure TTC
             print "attempting to configure TTC"
             if 0 == vfatBoard.parentOH.parentAMC.configureTTC(pulseDelay=0,L1Ainterval=250,ohN=options.gtx,enable=True):
                 print "TTC configured successfully"
             else:
                 raise Exception('RPC response was non-zero, TTC configuration failed')
-        else:
-            scanReg = "VThreshold1"
-            pass
-
-        scanDataSizeVFAT = (options.scanmax-options.scanmin+1)/options.stepSize
-        scanDataSizeNet = scanDataSizeVFAT * 24
-        scanData = (c_uint32 * scanDataSizeNet)()
         
-        # Perform the scan
-        rpcResp = vfatBoard.parentOH.performCalibrationScan(0, scanReg, scanData, nevts=options.nevts, 
-                                                            dacMin=options.scanmin, dacMax=options.scanmax, 
-                                                            stepSize=options.stepSize, mask=options.vfatmask)
-
-        if rpcResp != 0:
-            raise Exception('RPC response was non-zero, threshold scan failed')
-
-        sys.stdout.flush()
-        for vfat in range(0,24):
-            if (mask >> vfat) & 0x1: continue
-            vfatN[0] = vfat
-            trimRange[0] = (0x07 & vfatBoard.readVFAT(vfat,"ContReg3"))
-            for threshDAC in range(vfat*scanDataSizeVFAT,(vfat+1)*scanDataSizeVFAT,options.stepSize):
+            scanDataSizeVFAT = (options.scanmax-options.scanmin+1)/options.stepSize
+            scanDataSizeNet = scanDataSizeVFAT * 24
+            scanData = (c_uint32 * scanDataSizeNet)()
+            for chan in range(CHAN_MIN,CHAN_MAX):
+                vfatCH[0] = chan
+                print "Channel #"+str(chan)
+            
+                # Reset scanReg if needed
                 if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-                    vth1[0]  = int((scanData[threshDAC] & 0xff000000) >> 24)
-                    vth[0]   = vth2[0] - vth1[0]
-                    Nev[0] = options.nevts
-                    Nhits[0] = int(scanData[threshDAC] & 0xffffff)
-                else:
-                    if vfat == 0:
-                        # what happens if we don't scan from 0 to 255?
-                        vth1[0] = threshDAC
-                    else:
-                        # what happens if we don't scan from 0 to 255?
-                        vth1[0] = threshDAC - vfat*scanDataSizeVFAT
-                    Nev[0] = scanData[threshDAC] & 0xffff
-                    Nhits[0] = (scanData[threshDAC]>>16) & 0xffff
-                myT.Fill()
+                    scanReg = "VThreshold1PerChan"
+    
+                # Perform the scan
+                rpcResp = vfatBoard.parentOH.performCalibrationScan(chan, scanReg, scanData, enableCal=False, nevts=options.nevts, 
+                                                                    dacMin=options.scanmin, dacMax=options.scanmax, 
+                                                                    stepSize=options.stepSize, mask=options.vfatmask)
+    
+                if rpcResp != 0:
+                    raise Exception('RPC response was non-zero, threshold scan for channel %i failed'%chan)
+                
+                sys.stdout.flush()
+                for vfat in range(0,24):
+                    if (mask >> vfat) & 0x1: continue
+                    
+                    for threshDAC in range(vfat*scanDataSizeVFAT,(vfat+1)*scanDataSizeVFAT):
+                        try:
+                            if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+                                trimDAC = (0x1f & vfatBoard.readVFAT(vfat,"VFATChannels.ChanReg%d"%(chan)))
+                                gemData.fill(
+                                        calPhase = calPhasevals[vfat],
+                                        l1aTime = options.L1Atime,
+                                        latency = latvals[vfat],
+                                        mspl = msplvals[vfat],
+                                        Nev = options.nevts,
+                                        Nhits = (int(scanData[threshDAC] & 0xffffff)), 
+                                        trimDAC = trimDAC,
+                                        trimRange = trimRangevals[vfat],
+                                        vfatCH = chan,
+                                        #vfatID = vfatIDvals[vfat],
+                                        vfatN = vfat,
+                                        vth = (vt2vals[vfat] - int((scanData[threshDAC] & 0xff000000) >> 24)),
+                                        vth1 = (int((scanData[threshDAC] & 0xff000000) >> 24)),
+                                        vth2 = vt2vals[vfat]
+                                        )
+                            else:
+                                if vfat == 0:
+                                    # what happens if we don't scan from 0 to 255?
+                                    vthr = threshDAC
+                                else:
+                                    # what happens if we don't scan from 0 to 255?
+                                    vthr = threshDAC - vfat*scanDataSizeVFAT
+                                    pass
+                                
+                                trimDAC = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_AMPLITUDE"%(chan)))
+                                trimPolarity = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_POLARITY"%(chan)))
+                                gemData.fill(
+                                        calPhase = calPhasevals[vfat],
+                                        l1aTime = options.L1Atime,
+                                        latency = latvals[vfat],
+                                        mspl = msplvals[vfat],
+                                        Nev = (scanData[threshDAC] & 0xffff),
+                                        Nhits = ((scanData[threshDAC]>>16) & 0xffff),
+                                        trimDAC = trimDAC,
+                                        trimPolarity = trimPolarity,
+                                        vfatCH = chan,
+                                        #vfatID = vfatIDvals[vfat],
+                                        vfatN = vfat,
+                                        vth1 = vthr,
+                                        vthr = vthr
+                                        )
+                        except IndexError:
+                            print 'Unable to index data for channel %i'%chan
+                            print scanData[threshDAC]
+                    pass
+                gemData.autoSave()
                 pass
-            pass
-        myT.AutoSave("SaveSelf")
-
-        if options.trkdata:
+    
             if vfatBoard.parentOH.parentAMC.fwVersion < 3:
                 vfatBoard.parentOH.setTriggerSource(trgSrc)
             vfatBoard.parentOH.parentAMC.toggleTTCGen(options.gtx, False)
             pass
-        pass
+        else:
+            if not (vfatBoard.parentOH.parentAMC.fwVersion < 3):
+                print "For v3 electronics please use the --perchannel option"
+                print "Exiting"
+                sys.exit(os.EX_USAGE)
+    
+            if options.trkdata:
+                gemData.mode[0] = scanmode.THRESHTRK
 
-    # Place VFATs back in sleep mode
-    vfatBoard.setRunModeAll(mask, False, options.debug)
+                print "setting trigger source"
+                vfatBoard.parentOH.setTriggerSource(0x1)
+                
+                scanReg = "VThreshold1Trk"
+                
+                # Configure TTC
+                print "attempting to configure TTC"
+                if 0 == vfatBoard.parentOH.parentAMC.configureTTC(pulseDelay=0,L1Ainterval=250,ohN=options.gtx,enable=True):
+                    print "TTC configured successfully"
+                else:
+                    raise Exception('RPC response was non-zero, TTC configuration failed')
+            else:
+                gemData.mode[0] = scanmode.THRESHTRG
 
-    # Return to original comparator settings
-    if vfatBoard.parentOH.parentAMC.fwVersion >= 3:
-        for key,val in selCompVals_orig.iteritems():
-            if (mask >> key) & 0x1: continue
-            vfatBoard.writeVFAT(key,"CFG_SEL_COMP_MODE",val)
-        for key,val in forceEnZCCVals_orig.iteritems():
-            if (mask >> key) & 0x1: continue
-            vfatBoard.writeVFAT(key,"CFG_FORCE_EN_ZCC",val)
-
-except Exception as e:
-    gemData.autoSave()
-    print "An exception occurred", e
-finally:
-    myF.cd()
-    gemData.write()
-    myF.Close()
+                scanReg = "VThreshold1"
+                pass
+    
+            scanDataSizeVFAT = (options.scanmax-options.scanmin+1)/options.stepSize
+            scanDataSizeNet = scanDataSizeVFAT * 24
+            scanData = (c_uint32 * scanDataSizeNet)()
+            
+            # Perform the scan
+            rpcResp = vfatBoard.parentOH.performCalibrationScan(0, scanReg, scanData, nevts=options.nevts, 
+                                                                dacMin=options.scanmin, dacMax=options.scanmax, 
+                                                                stepSize=options.stepSize, mask=options.vfatmask)
+    
+            if rpcResp != 0:
+                raise Exception('RPC response was non-zero, threshold scan failed')
+    
+            sys.stdout.flush()
+            for vfat in range(0,24):
+                if (mask >> vfat) & 0x1: continue
+                for threshDAC in range(vfat*scanDataSizeVFAT,(vfat+1)*scanDataSizeVFAT,options.stepSize):
+                    if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+                        gemData.fill(
+                                calPhase = calPhasevals[vfat],
+                                l1aTime = options.L1Atime,
+                                latency = latvals[vfat],
+                                mspl = msplvals[vfat],
+                                Nev = options.nevts,
+                                Nhits = (int(scanData[threshDAC] & 0xffffff)), 
+                                trimRange = trimRangevals[vfat],
+                                #vfatID = vfatIDvals[vfat],
+                                vfatN = vfat,
+                                vth = (vt2vals[vfat] - (int((scanData[threshDAC] & 0xff000000) >> 24))),
+                                vth1 = (int((scanData[threshDAC] & 0xff000000) >> 24)),
+                                vth2 = vt2vals[vfat]
+                                )
+                    else:
+                        if vfat == 0:
+                            # what happens if we don't scan from 0 to 255?
+                            vthr = threshDAC
+                        else:
+                            # what happens if we don't scan from 0 to 255?
+                            vthr = threshDAC - vfat*scanDataSizeVFAT
+                            pass
+                        gemData.fill(
+                                calPhase = calPhasevals[vfat],
+                                l1aTime = options.L1Atime,
+                                latency = latvals[vfat],
+                                mspl = msplvals[vfat],
+                                Nev = (scanData[threshDAC] & 0xffff),
+                                Nhits = ((scanData[threshDAC]>>16) & 0xffff),
+                                #vfatID = vfatIDvals[vfat],
+                                vfatN = vfat,
+                                vth1 = vthr,
+                                vthr = vthr
+                                )
+                        pass
+                    pass
+                pass
+            gemData.autoSave("SaveSelf")
+    
+            if options.trkdata:
+                if vfatBoard.parentOH.parentAMC.fwVersion < 3:
+                    vfatBoard.parentOH.setTriggerSource(trgSrc)
+                vfatBoard.parentOH.parentAMC.toggleTTCGen(options.gtx, False)
+                pass
+            pass
+    
+        # Place VFATs back in sleep mode
+        vfatBoard.setRunModeAll(mask, False, options.debug)
+    
+        # Return to original comparator settings
+        if vfatBoard.parentOH.parentAMC.fwVersion >= 3:
+            for key,val in selCompVals_orig.iteritems():
+                if (mask >> key) & 0x1: continue
+                vfatBoard.writeVFAT(key,"CFG_SEL_COMP_MODE",val)
+            for key,val in forceEnZCCVals_orig.iteritems():
+                if (mask >> key) & 0x1: continue
+                vfatBoard.writeVFAT(key,"CFG_FORCE_EN_ZCC",val)
+    
+    except Exception as e:
+        gemData.autoSave()
+        print "An exception occurred", e
+    finally:
+        myF.cd()
+        gemData.write()
+        myF.Close()

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -12,6 +12,7 @@ if __name__ == '__main__':
     from array import array
     from ctypes import *
     
+    from gempython.tools.optohybrid_user_functions_uhal import scanmode
     from gempython.tools.vfat_user_functions_xhal import *
     
     from gempython.vfatqc.qcoptions import parser

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     
     # Check options
     from gempython.vfatqc.qcutilities import inputOptionsValid
-    if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
+    if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC.fwVersion):
         exit(os.EX_USAGE)
         pass
     if options.scanmin not in range(256) or options.scanmax not in range(256) or not (options.scanmax > options.scanmin):

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -31,10 +31,6 @@ parser.add_option("--zcc", action="store_true", dest="scanZCC",
 
 (options, args) = parser.parse_args()
 
-if options.vt2 not in range(256):
-    print "Invalid VT2 specified: %d, must be in range [0,255]"%(options.vt2)
-    exit(1)
-
 remainder = (options.scanmax-options.scanmin+1) % options.stepSize
 if remainder != 0:
     options.scanmax = options.scanmax + remainder
@@ -78,7 +74,19 @@ startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
 print startTime
 Date = startTime
 
+# Open rpc connection to hw
 vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
+
+# Check options
+import ...vfatqc.qcutilities import inputOptionsValid
+if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
+    exit(os.EX_USAGE)
+    pass
+if options.scanmin not in range(256) or options.scanmax not in range(256) or not (options.scanmax > options.scanmin):
+    print("Invalid scan parameters specified [min,max] = [%d,%d]"%(options.scanmin,options.scanmax))
+    print("Scan parameters must be in range [0,255] and min < max")
+    exit(1)
+    pass
 
 CHAN_MIN = options.chMin
 CHAN_MAX = options.chMax + 1

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -78,7 +78,7 @@ Date = startTime
 vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
 
 # Check options
-from ...vfatqc.qcutilities import inputOptionsValid
+from gempython.vfatqc.qcutilities import inputOptionsValid
 if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
     exit(os.EX_USAGE)
     pass

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -175,7 +175,6 @@ if __name__ == '__main__':
             scanDataSizeNet = scanDataSizeVFAT * 24
             scanData = (c_uint32 * scanDataSizeNet)()
             for chan in range(CHAN_MIN,CHAN_MAX):
-                vfatCH[0] = chan
                 print "Channel #"+str(chan)
             
                 # Reset scanReg if needed
@@ -197,7 +196,7 @@ if __name__ == '__main__':
                     for threshDAC in range(vfat*scanDataSizeVFAT,(vfat+1)*scanDataSizeVFAT):
                         try:
                             if vfatBoard.parentOH.parentAMC.fwVersion < 3:
-                                trimDAC = (0x1f & vfatBoard.readVFAT(vfat,"VFATChannels.ChanReg%d"%(chan)))
+                                #trimDAC = (0x1f & vfatBoard.readVFAT(vfat,"VFATChannels.ChanReg%d"%(chan)))
                                 gemData.fill(
                                         calPhase = calPhasevals[vfat],
                                         l1aTime = options.L1Atime,
@@ -205,7 +204,7 @@ if __name__ == '__main__':
                                         mspl = msplvals[vfat],
                                         Nev = options.nevts,
                                         Nhits = (int(scanData[threshDAC] & 0xffffff)), 
-                                        trimDAC = trimDAC,
+                                        #trimDAC = trimDAC,
                                         trimRange = trimRangevals[vfat],
                                         vfatCH = chan,
                                         #vfatID = vfatIDvals[vfat],
@@ -223,8 +222,8 @@ if __name__ == '__main__':
                                     vthr = threshDAC - vfat*scanDataSizeVFAT
                                     pass
                                 
-                                trimDAC = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_AMPLITUDE"%(chan)))
-                                trimPolarity = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_POLARITY"%(chan)))
+                                #trimDAC = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_AMPLITUDE"%(chan)))
+                                #trimPolarity = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_POLARITY"%(chan)))
                                 gemData.fill(
                                         calPhase = calPhasevals[vfat],
                                         l1aTime = options.L1Atime,
@@ -232,8 +231,8 @@ if __name__ == '__main__':
                                         mspl = msplvals[vfat],
                                         Nev = (scanData[threshDAC] & 0xffff),
                                         Nhits = ((scanData[threshDAC]>>16) & 0xffff),
-                                        trimDAC = trimDAC,
-                                        trimPolarity = trimPolarity,
+                                        #trimDAC = trimDAC,
+                                        #trimPolarity = trimPolarity,
                                         vfatCH = chan,
                                         #vfatID = vfatIDvals[vfat],
                                         vfatN = vfat,

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -78,7 +78,7 @@ Date = startTime
 vfatBoard = HwVFAT(options.slot, options.gtx, options.shelf, options.debug)
 
 # Check options
-import ...vfatqc.qcutilities import inputOptionsValid
+from ...vfatqc.qcutilities import inputOptionsValid
 if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC):
     exit(os.EX_USAGE)
     pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

### Previous Trim Algorithm
The previous trim algorithm for vfat3 makes a false assumption.  The strategy was:

1. Take an initial scurve with all channel registers set to zero, 
2. For a given `vfat3` determine the distribution of `scurvePOI = scurve_mu - ztrim * scurve_width`,
3. For the `i^th` scurve determine the value `trim = scruvePOI - <scurvePOI>`,
4. Set the `trim` value to the trim amplitude register of the `i^th` channel, the sign of `trim` determines the trim polarity register,
5. Take a final s-curve to evaluate the trim procedure.

### Flawed Assumption of Previous Trim Algorithm
While this procedure has success in reducing the spread of the `scurvePOI` distribution it makes a flawed assumption.  Namely that the value `trim = scruvePOI - <scurvePOI>` which is in terms of `CFG_CAL_DAC` units (e.g. the step size of this register) corresponds to step size of the `ARM_TRIM_AMPLITUDE`.

The step size of the `CFG_CAL_DAC` register is in `fC` and is provided by an external calibration.  The step size of the `ARM_TRIM_AMPLITUDE` is reported in the `vfat3` manual as having an LSB of 0.5 mV.  So assumptions 4 is not correct.  This also can explain the slight under/overshooting in trimming that was been previously reported when comparing the initial s-curve to the post trim s-curve.

### Correction to Trim Algorithm
The correction that is implemented is to require:

1. The trimming require the user provides an input calibration file (e.g. addition of the `--calFile` argument),
2. The `scurvePOI` values are converted into charge units (fC) by the `ScanDataFitter` class using hte provided calibration file,
3. The `vfat3` manual states that the calibration unit of `vfat3` uses a `100 fF` capacitor to perform the charge injection; therefore the difference `scruvePOI - <scurvePOI>` in fC can be converted to volts via `Q = CV` -> `V = Q / C`
4. Once `scruvePOI - <scurvePOI>` is converted into voltage it can be converted into DAC units of the `ARM_TRIM_AMPLITUDE` register by converting into `mV` and then dividing by the LSB (`0.5 mV`) of the `ARM_TRIM_AMPLITUDE` register.

After arriving at the end of step 4 this will then provide a more accurate trim procedure that should resolve this over-under shoot that has been exhibited and force the distribution of `scruvePOI` to even  narrower post trimming.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See above discussion.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing is in progress.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
