### PR TITLE
adding chan argument to ultraLatency.py [V3]

### DIFF
--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     parser.add_option("--amc13local", action="store_true", dest="amc13local",
                       help="Set up for using AMC13 local trigger generator", metavar="amc13local")
     parser.add_option("--chan", type="int", dest="chan",
-                      help="Channel on the VFATs on which to run the latency scan. This only applies when calling the --internal option; otherwise the default value is used.", metavar="chan", default=0)
+                      help="Channel on the VFATs on which to run the latency scan. This only applies when calling the --internal option; otherwise the OR of all channels is used.", metavar="chan", default=0)
     parser.add_option("--fakeTTC", action="store_true", dest="fakeTTC",
                       help="Set up for using AMC13 local TTC generator", metavar="fakeTTC")
     parser.add_option("--filename", type="string", dest="filename", default="LatencyScanData.root",

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -41,8 +41,10 @@ if __name__ == '__main__':
                       help="Calibration Module is set to use voltage step pulsing instead of default current pulse injection", 
                       metavar="voltageStepPulse")
     parser.add_option("--vt2", type="int", dest="vt2",
-                      help="VThreshold2 DAC value for all VFATs (v2b electronics only)", metavar="vt2", default=0)
-    
+                      help="VThreshold2 DAC value for all VFATs (v2b electronics only)", metavar="vt2", default=0) 
+    parser.add_option("--chan", type="int", dest="chan",
+                      help="Channel on the VFATs on which to run the latency scan", metavar="chan", default=0)
+
     parser.set_defaults(scanmin=153,scanmax=172,nevts=500)
     (options, args) = parser.parse_args()
     
@@ -169,7 +171,7 @@ if __name__ == '__main__':
         enableCalPulse=False
         if options.internal:
             enableCalPulse=True
-            scanChan=0
+            scanChan=options.chan
             if vfatBoard.parentOH.parentAMC.fwVersion < 3:
                 vfatBoard.parentOH.setTriggerSource(0x1)
             

--- a/ultraLatency.py
+++ b/ultraLatency.py
@@ -20,6 +20,8 @@ if __name__ == '__main__':
     
     parser.add_option("--amc13local", action="store_true", dest="amc13local",
                       help="Set up for using AMC13 local trigger generator", metavar="amc13local")
+    parser.add_option("--chan", type="int", dest="chan",
+                      help="Channel on the VFATs on which to run the latency scan. This only applies when calling the --internal option; otherwise the default value is used.", metavar="chan", default=0)
     parser.add_option("--fakeTTC", action="store_true", dest="fakeTTC",
                       help="Set up for using AMC13 local TTC generator", metavar="fakeTTC")
     parser.add_option("--filename", type="string", dest="filename", default="LatencyScanData.root",
@@ -42,8 +44,6 @@ if __name__ == '__main__':
                       metavar="voltageStepPulse")
     parser.add_option("--vt2", type="int", dest="vt2",
                       help="VThreshold2 DAC value for all VFATs (v2b electronics only)", metavar="vt2", default=0) 
-    parser.add_option("--chan", type="int", dest="chan",
-                      help="Channel on the VFATs on which to run the latency scan", metavar="chan", default=0)
 
     parser.set_defaults(scanmin=153,scanmax=172,nevts=500)
     (options, args) = parser.parse_args()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I have added a --chan argument to ultraLatency.py that allows the user to specify any single channel over which to run a latency scan on the VFATs. Previously, by default ultraLatency.py always conducted the scan over Channel 0.

## Description
<!--- Describe your changes in detail -->
I have added an argument "--chan" in the options parser to allow a channel to be specified for the scan. The default value of this argument is 0, as it was before. Then, in a conditional statement that asks if options.internal == True, I have passed options.chan to the variable scanChan instead of the value 0. This is on Line 174.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
In particular, some of the VFATs on the Integration stand have dead Channel 0 and so do not respond to the latency scan. This added functionality allows us to perform the latency scan over good channels in the VFATs in the event that Channel 0 (the previous default) is dead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After implementing this change, I performed a latency scan with positive results. On the current integration stand setup, I have run the command "ultraLatency.py -c eagle64 -g0 --L1Atime=250 --mspl=3 --pulseDelay=40 --voltageStepPulse --internal --stepSize=1 --shelf=1 --scanmin=1 --scanmax=250 --chan=10" and can see during the course of the scan that values are written to registers corresponding to CHANNEL10 for all VFATs. In particular, VFAT 19 has a dead channel 0 but good channels otherwise (for the most part). If the latency scan is performed with the default CHANNEL0, then the scan result for VFAT 19 looks like the first screenshot below. When the channel is specified as --chan=10, then the result for VFAT 19 is the second screenshot below, showing a response.

### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/26880226/42945768-804e396e-8b69-11e8-9607-bf8d9fe39f62.png)
![image](https://user-images.githubusercontent.com/26880226/42945693-4f0ea226-8b69-11e8-957d-5229466f637a.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
