### PR TITLE
New Feature: Readback Channel Registers in Python Tools [V3]

### DIFF
--- a/confChamber.py
+++ b/confChamber.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
 
             dict_readBack = {}
             if vfatBoard.parentOH.parentAMC.fwVersion > 2:
-                dict_readBack = { "trimDAC":"VFAT_CHANNELS.CHANNEL", "trimPolarity":"VFAT_CHANNELS.CHANNEL", "mask":"VFAT_CHANNELS.CHANNEL" }
+                dict_readBack = { "trimDAC":"VFAT_CHANNELS.CHANNEL", "trimPolarity":"VFAT_CHANNELS.CHANNEL", "mask":"VFAT_CHANNELS.CHANNEL", "vfatID":"HW_CHIP_ID" }
                 print 'Comparing Currently Stored Channel Registers with %s'%options.chConfig
                 readBackCheckV3(chTree, dict_readBack, vfatBoard, options.vfatmask)
     
@@ -102,7 +102,7 @@ if __name__ == '__main__':
 
             dict_readBack = {}
             if vfatBoard.parentOH.parentAMC.fwVersion > 2:
-                dict_readBack = { "trimDAC":"VFAT_CHANNELS.CHANNEL", "trimPolarity":"VFAT_CHANNELS.CHANNEL", "mask":"VFAT_CHANNELS.CHANNEL" }
+                dict_readBack = { "trimDAC":"VFAT_CHANNELS.CHANNEL", "trimPolarity":"VFAT_CHANNELS.CHANNEL", "mask":"VFAT_CHANNELS.CHANNEL", "vfatID":"HW_CHIP_ID" }
                 print 'Comparing Currently Stored Channel Registers with %s'%options.chConfig
                 readBackCheckV3(chTree, dict_readBack, vfatBoard, options.vfatmask)
     
@@ -146,7 +146,7 @@ if __name__ == '__main__':
             
             if vfatBoard.parentOH.parentAMC.fwVersion > 2:
                 print 'Comparing Curently Stored VFAT Registers with %s'%options.vfatConfig
-                dict_readBack = { "vt1":"CFG_THR_ARM_DAC" }
+                dict_readBack = { "vfatID":HW_CHIP_ID, "vt1":"CFG_THR_ARM_DAC" }
                 readBackCheck(vfatTree, dict_readBack, vfatBoard, options.vfatmask, options.vt1bump)
     
         except Exception as e:

--- a/confChamber.py
+++ b/confChamber.py
@@ -12,9 +12,8 @@ if __name__ == '__main__':
     from gempython.tools.vfat_user_functions_xhal import *
     from gempython.gemplotting.mapping.chamberInfo import chamber_vfatDACSettings
     from gempython.vfatqc.qcoptions import parser
-    from gempython.vfatqc.qcutilities import inputOptionsValid, setChannelRegisters
-    #from gempython.vfatqc.qcutilities import readBackCheck 
-    
+    from gempython.vfatqc.qcutilities import inputOptionsValid, readBackCheckV3, setChannelRegisters
+
     parser.add_option("--chConfig", type="string", dest="chConfig", default=None,
                       help="Specify file containing channel settings from anaUltraSCurve", metavar="chConfig")
     parser.add_option("--compare", action="store_true", dest="compare",
@@ -79,21 +78,15 @@ if __name__ == '__main__':
         try:
             inF = r.TFile(options.filename)
             chTree = inF.Get("scurveFitTree")
-            dict_readBack = {}
-            if vfatBoard.parentOH.parentAMC.fwVersion > 2:
-                # Need some pre-string append that is "VFAT_CHANNELS.CHANNEL"
-                dict_readBack = { "trimDAC":"ARM_TRIM_AMPLITUDE", "trimPolarity":"ARM_TRIM_POLARITY", "mask":"MASK" }
-            else:
-                dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg" }
-                pass
-    
             if not options.compare:
                 print 'Configuring Channel Registers based on %s'%options.filename        
                 setChannelRegisters(vfatBoard, chTree, options.vfatmask)
-                pass
-     
-            #print 'Comparing Currently Stored Channel Registers with %s'%options.filename
-            #readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
+
+            dict_readBack = {}
+            if vfatBoard.parentOH.parentAMC.fwVersion > 2:
+                dict_readBack = { "trimDAC":"VFAT_CHANNELS.CHANNEL", "trimPolarity":"VFAT_CHANNELS.CHANNEL", "mask":"VFAT_CHANNELS.CHANNEL" }
+                print 'Comparing Currently Stored Channel Registers with %s'%options.chConfig
+                readBackCheckV3(chTree, dict_readBack, vfatBoard, options.vfatmask)
     
         except Exception as e:
             print '%s does not seem to exist'%options.filename
@@ -103,21 +96,15 @@ if __name__ == '__main__':
         try:
             chTree = r.TTree('chTree','Tree holding Channel Configuration Parameters')
             chTree.ReadFile(options.chConfig)
-            dict_readBack = {}
-            if vfatBoard.parentOH.parentAMC.fwVersion > 2:
-                # Need some pre-string append that is "VFAT_CHANNELS.CHANNEL"
-                # but that needs to be done in readBackCheck(...) when looping over channels
-                dict_readBack = { "trimDAC":"ARM_TRIM_AMPLITUDE", "trimPolarity":"ARM_TRIM_POLARITY", "mask":"MASK" }
-            else:
-                dict_readBack = { "trimDAC":"VFATChannels.ChanReg", "mask":"VFATChannels.ChanReg" }
-    
             if not options.compare:
                 print 'Configuring Channel Registers based on %s'%options.chConfig
                 setChannelRegisters(vfatBoard, chTree, options.vfatmask)
-                pass
-    
-            #print 'Comparing Currently Stored Channel Registers with %s'%options.chConfig
-            #readBackCheck(chTree, dict_readBack, ohboard, options.gtx)
+
+            dict_readBack = {}
+            if vfatBoard.parentOH.parentAMC.fwVersion > 2:
+                dict_readBack = { "trimDAC":"VFAT_CHANNELS.CHANNEL", "trimPolarity":"VFAT_CHANNELS.CHANNEL", "mask":"VFAT_CHANNELS.CHANNEL" }
+                print 'Comparing Currently Stored Channel Registers with %s'%options.chConfig
+                readBackCheckV3(chTree, dict_readBack, vfatBoard, options.vfatmask)
     
         except Exception as e:
             print '%s does not seem to exist'%options.filename
@@ -135,7 +122,6 @@ if __name__ == '__main__':
         try:
             vfatTree = r.TTree('vfatTree','Tree holding VFAT Configuration Parameters')
             vfatTree.ReadFile(options.vfatConfig)
-            #dict_readBack = { "vt1":"VThreshold1", "trimRange":"ContReg3" }
     
             if not options.compare:
                 print 'Configuring VFAT Registers based on %s'%options.vfatConfig
@@ -158,10 +144,10 @@ if __name__ == '__main__':
                     if not (vfatBoard.parentOH.parentAMC.fwVersion > 2):
                         vfatBoard.writeVFAT(int(event.vfatN), "ContReg3", int(event.trimRange),options.debug)
             
-            #print 'Comparing Curently Stored VFAT Registers with %s'%options.vfatConfig
-            #if options.vt1bump != 0:
-            #    print "Mismatches between write & readback valus for VThreshold1 should be exactly %i" %(options.vt1bump)
-            #readBackCheck(vfatTree, dict_readBack, ohboard, options.gtx)
+            if vfatBoard.parentOH.parentAMC.fwVersion > 2:
+                print 'Comparing Curently Stored VFAT Registers with %s'%options.vfatConfig
+                dict_readBack = { "vt1":"CFG_THR_ARM_DAC" }
+                readBackCheck(vfatTree, dict_readBack, vfatBoard, options.vfatmask, options.vt1bump)
     
         except Exception as e:
             print '%s does not seem to exist'%options.filename

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     print 'opened connection'
 
     # Check options
-    from gempython.vfatqc.qcutilities import inputOptionsValid
+    from gempython.vfatqc.qcutilities import getChannelRegisters, inputOptionsValid
     if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC.fwVersion):
         exit(os.EX_USAGE)
         pass
@@ -135,6 +135,8 @@ if __name__ == '__main__':
             vals  = vfatBoard.readAllVFATs("CFG_THR_ARM_DAC", mask)
             vthrvals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),range(0,24)))
             
+            chanRegData = getChannelRegisters(vfatBoard,mask)
+
             pass
 
         # Make sure no channels are receiving a cal pulse
@@ -190,8 +192,6 @@ if __name__ == '__main__':
                                     vthr = vt1vals[vfat]
                                     )
                         else:
-                            #trimDAC = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_AMPLITUDE"%(chan)))
-                            #trimPolarity = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_POLARITY"%(chan)))
                             gemData.fill(
                                     calPhase = calPhasevals[vfat],
                                     isCurrentPulse = isCurrentPulse,
@@ -201,8 +201,8 @@ if __name__ == '__main__':
                                     Nev = (scanData[vcalDAC] & 0xffff),
                                     Nhits = ((scanData[vcalDAC]>>16) & 0xffff),
                                     pDel = options.pDel,
-                                    #trimDAC = trimDAC,
-                                    #trimPolarity = trimPolarity,
+                                    trimDAC = chanRegData[chan+vfat*128]['ARM_TRIM_AMPLITUDE'],
+                                    trimPolarity = chanRegData[chan+vfat*128]['ARM_TRIM_POLARITY'],
                                     vcal = (options.scanmin + (vcalDAC - vfat*scanDataSizeVFAT) * options.stepSize),
                                     vfatCH = chan,
                                     #vfatID = vfatIDvals[vfat],

--- a/ultraThreshold.py
+++ b/ultraThreshold.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     print 'opened connection'
     
     # Check options
-    from gempython.vfatqc.qcutilities import inputOptionsValid
+    from gempython.vfatqc.qcutilities import getChannelRegisters, inputOptionsValid
     if not inputOptionsValid(options, vfatBoard.parentOH.parentAMC.fwVersion):
         exit(os.EX_USAGE)
         pass
@@ -140,6 +140,8 @@ if __name__ == '__main__':
                 forceEnZCCVals =  dict(map(lambda slotID: (slotID, vals[slotID]&0xff),
                     range(0,24)))
                 pass
+
+            chanRegData = getChannelRegisters(vfatBoard,mask)
         else:
             vals = vfatBoard.readAllVFATs("CalPhase",   0x0)
             calPhasevals = dict(map(lambda slotID: (slotID, bin(vals[slotID]).count("1")),range(0,24)))
@@ -227,8 +229,6 @@ if __name__ == '__main__':
                                     vthr = threshDAC - vfat*scanDataSizeVFAT
                                     pass
                                 
-                                #trimDAC = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_AMPLITUDE"%(chan)))
-                                #trimPolarity = (0x3f & vfatBoard.readVFAT(vfat,"VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_POLARITY"%(chan)))
                                 gemData.fill(
                                         calPhase = calPhasevals[vfat],
                                         l1aTime = options.L1Atime,
@@ -236,8 +236,8 @@ if __name__ == '__main__':
                                         mspl = msplvals[vfat],
                                         Nev = (scanData[threshDAC] & 0xffff),
                                         Nhits = ((scanData[threshDAC]>>16) & 0xffff),
-                                        #trimDAC = trimDAC,
-                                        #trimPolarity = trimPolarity,
+                                        trimDAC = chanRegData[chan+vfat*128]['ARM_TRIM_AMPLITUDE'],
+                                        trimPolarity = chanRegData[chan+vfat*128]['ARM_TRIM_POLARITY'],
                                         vfatCH = chan,
                                         #vfatID = vfatIDvals[vfat],
                                         vfatN = vfat,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Goal to enable `readBackCheck()` for `confChamber.py` and allow `ultraScurve.py` and `ultraThreshold.py` to store channel register information when storing raw data.

Right now once channel registers are set they are never stored in any of the output data and cannot be ready back without a large number of atomic transactions.

Requires: https://github.com/cms-gem-daq-project/cmsgemos/pull/192

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Provides functionality to cross-check that after writing configuration it matches expectation (by providing `readBackCheckV3(...)`) and stores this information in our "ultra" scans.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
http://cmsonline.cern.ch/cms-elog/1055032

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
