### PR TITLE
WIP: Fixed run_scans.py to run in series mode with ultraLatency.py

### DIFF
--- a/run_scans.py
+++ b/run_scans.py
@@ -3,7 +3,7 @@
 def launch(args):
   return launchArgs(*args)
 
-def launchArgs(tool, cardName, shelf, link, chamber, vfatmask, scanmin, scanmax, nevts, startTime, stepSize=1,
+def launchArgs(tool, cardName, shelf, link, vfatmask, scanmin, scanmax, nevts, startTime, stepSize=1,
                vt1=None,vt2=0,mspl=None,perchannel=False,trkdata=False,ztrim=4.0,
                config=False,amc13local=False,t3trig=False, randoms=0, throttle=0,
                internal=False, debug=False, voltageStepPulse=False):
@@ -85,7 +85,7 @@ def launchArgs(tool, cardName, shelf, link, chamber, vfatmask, scanmin, scanmax,
     pass
   elif tool == "fastLatency.py":
     scanType = "latency/trig"
-    dirPath = "%s/%s/%s/"%(dataPath,chamber,scanType)
+    dirPath = "%s/%s/%s/"%(dataPath,chamber_config[link],scanType)
     setupCmds.append( ["mkdir","-p",dirPath+startTime] )
     setupCmds.append( ["unlink",dirPath+"current"] )
     setupCmds.append( ["ln","-s",startTime,dirPath+"current"] )
@@ -96,7 +96,7 @@ def launchArgs(tool, cardName, shelf, link, chamber, vfatmask, scanmin, scanmax,
     pass
   elif tool == "ultraLatency.py":
     scanType = "latency/trk"
-    dirPath = "%s%s/%s/"%(dataPath,chamber,scanType)
+    dirPath = "%s/%s/%s/"%(dataPath,chamber_config[link],scanType)
     setupCmds.append( ["mkdir","-p",dirPath+startTime] )
     setupCmds.append( ["unlink",dirPath+"current"] )
     setupCmds.append( ["ln","-s",startTime,dirPath+"current"] )
@@ -225,13 +225,11 @@ if __name__ == '__main__':
   if options.series:
 #    print "Running jobs in serial mode"
     for link in chamber_config.keys():
-      chamber = chamber_config[link]
       vfatMask = chamber_vfatMask[link]
       launch([ options.tool,
                options.cardName,
                options.shelf,
                link,
-               chamber,
                vfatMask,
                options.scanmin,
                options.scanmax,

--- a/run_scans.py
+++ b/run_scans.py
@@ -112,6 +112,10 @@ def launchArgs(tool, cardName, shelf, link, vfatmask, scanmin, scanmax, nevts, s
     setupCmds.append( ["unlink",dirPath+"current"] )
     setupCmds.append( ["ln","-s",startTime,dirPath+"current"] )
     dirPath = dirPath+startTime
+    preCmd = ["confChamber.py","--cardName=%s"%(cardName),"-g%i"%(link),"--zeroChan"]
+    if vt1 in range(256):
+      preCmd.append("--vt1=%s"%(vt1))
+      pass
     cmd.append( "--filename=%s/LatencyScanData.root"%dirPath )
     cmd.append( "--scanmin=%i"%(scanmin) )
     cmd.append( "--scanmax=%i"%(scanmax) )

--- a/run_scans.py
+++ b/run_scans.py
@@ -3,10 +3,11 @@
 def launch(args):
   return launchArgs(*args)
 
-def launchArgs(tool, cardName, shelf, link, vfatmask, scanmin, scanmax, nevts, startTime, stepSize=1,
-               vt1=None,vt2=0,mspl=None,perchannel=False,trkdata=False,ztrim=4.0,
+def launchArgs(tool, cardName, shelf, link, vfatmask, scanmin, scanmax, nevts, startTime, stepSize,
+               vt1,vt2,mspl,l1atime,perchannel=False,trkdata=False,ztrim=4.0,
                config=False,amc13local=False,t3trig=False, randoms=0, throttle=0,
-               internal=False, debug=False, voltageStepPulse=False):
+               internal=False, debug=False, voltageStepPulse=False, latency=33, CalPhase=0,
+               chMin=0, chMax=127, calSF=0, pulseDelay=40):
   import os,sys
   import subprocess
   from subprocess import CalledProcessError
@@ -20,7 +21,7 @@ def launchArgs(tool, cardName, shelf, link, vfatmask, scanmin, scanmax, nevts, s
   #Build Commands
   setupCmds = []
   preCmd = None
-  cmd = ["%s"%(tool),"--cardName=%s"%(cardName),"-g%s"%(link),"--shelf=%s"%(shelf), "--nevts=%s"%(nevts), "--vfatmask=0x%x"%(vfatmask)]
+  cmd = ["%s"%(tool),"--cardName=%s"%(cardName),"-g%s"%(link),"--L1Atime=%s"%(l1atime), "--mspl=%s"%(mspl),"--nevts=%s"%(nevts), "--vfatmask=0x%x"%(vfatmask), "--pulseDelay=%s"%(pulseDelay), "--scanmin=%s"%(scanmin), "--scanmax=%s"%(scanmax), "--ztrim=%s"%(ztrim),  "--stepSize=%s"%(stepSize)]
   if debug:
     cmd.append( "--debug")
   if tool == "ultraScurve.py":
@@ -32,12 +33,21 @@ def launchArgs(tool, cardName, shelf, link, vfatmask, scanmin, scanmax, nevts, s
     setupCmds.append( ["ln","-s",startTime,dirPath+"current"] )
     dirPath = dirPath+startTime
     cmd.append( "--filename=%s/SCurveData.root"%dirPath )
-    if mspl:
-      cmd.append( "--mspl=%i"%(mspl) )
-    preCmd = ["confChamber.py","-cardName=%s"%(cardName),"-g%i"%(link),"--shelf=%i"%(shelf)]
+    cmd.append( "--latency=%s"%(latency))
+    preCmd = ["confChamber.py","--cardName=%s"%(cardName),"-g%i"%(link),"--zeroChan"]
     if vt1 in range(256):
-      preCmd.append("--vt1=%i"%(vt1))
+      preCmd.append("--vt1=%s"%(vt1))
       pass
+    if voltageStepPulse:
+      cmd.append("--voltageStepPulse")
+    if CalPhase:
+      cmd.append("--CalPhase=%s"%(CalPhase))
+    if chMin:
+      cmd.append("--chMin=%s"%(chMin))
+    if chMax:
+      cmd.append("--chMax=%s"%(chMax))
+#    if calSF:
+#      cmd.append("--calSF=%s"%(calSF))
     pass
   elif tool == "trimChamber.py":
     scanType = "trim"
@@ -157,10 +167,20 @@ if __name__ == '__main__':
 
   parser.add_option("--amc13local", action="store_true", dest="amc13local",
                     help="Set up for using AMC13 local trigger generator", metavar="amc13local")
+  parser.add_option("--CalPhase", type="int", dest = "CalPhase", default = 0,
+                    help="Specify CalPhase. Must be in range 0-8", metavar="CalPhase")
+  parser.add_option("--calSF", type="int", dest = "calSF", default = 0,
+                    help="V3 electroncis only. Value of the CFG_CAL_FS register", metavar="calSF")
+  parser.add_option("--chMin", type="int", dest = "chMin", default = 0,
+                    help="Specify minimum channel number to scan", metavar="chMin")
+  parser.add_option("--chMax", type="int", dest = "chMax", default = 127,
+                    help="Specify maximum channel number to scan", metavar="chMax")
   parser.add_option("--config", action="store_true", dest="config",
                     help="Configure chambers before running scan", metavar="config")
   parser.add_option("--internal", action="store_true", dest="internal",
                     help="Run a latency scan using the internal calibration pulse", metavar="internal")
+  parser.add_option("--latency", type="int", dest = "latency", default = 37,
+                    help="Specify Latency", metavar="latency")
   parser.add_option("--perchannel", action="store_true", dest="perchannel",
                     help="Run a per-channel VT1 scan", metavar="perchannel")
   parser.add_option("--randoms", type="int", default=0, dest="randoms",
@@ -239,6 +259,7 @@ if __name__ == '__main__':
                options.vt1,
                options.vt2,
                options.MSPL,
+               options.L1Atime,
                options.perchannel,
                options.trkdata,
                options.ztrim,
@@ -249,7 +270,13 @@ if __name__ == '__main__':
                options.throttle,
                options.internal,
                options.debug,
-               options.voltageStepPulse
+               options.voltageStepPulse,
+               options.latency,
+               options.CalPhase,
+               options.calSF,
+               options.chMin,
+               options.chMax,
+               options.pDel
       ])
       pass
     pass

--- a/run_scans.py
+++ b/run_scans.py
@@ -244,13 +244,13 @@ if __name__ == '__main__':
                          [options.randoms for x in range(len(chamber_config))],
                          [options.throttle for x in range(len(chamber_config))],
                          [options.internal for x in range(len(chamber_config))],
-                         [options.debug for x in range(len(chamber_config))]
-                         [options.calSF for x in range(len(chamber_config))]
-                         [options.chMin for x in range(len(chamber_config))]
-                         [options.chMax for x in range(len(chamber_config))]
-                         [options.pDel for x in range(len(chamber_config))]
-                         [options.voltageStepPulse for x in range(len(chamber_config))]
-                         [options.latency for x in range(len(chamber_config))]
+                         [options.debug for x in range(len(chamber_config))],
+                         [options.calSF for x in range(len(chamber_config))],
+                         [options.chMin for x in range(len(chamber_config))],
+                         [options.chMax for x in range(len(chamber_config))],
+                         [options.pDel for x in range(len(chamber_config))],
+                         [options.voltageStepPulse for x in range(len(chamber_config))],
+                         [options.latency for x in range(len(chamber_config))],
                          [options.CalPhase for x in range(len(chamber_config))]
 
                          )

--- a/run_scans.py
+++ b/run_scans.py
@@ -40,14 +40,15 @@ def launchArgs(tool, cardName, shelf, link, vfatmask, scanmin, scanmax, nevts, s
       pass
     if voltageStepPulse:
       cmd.append("--voltageStepPulse")
+    else:
+        if calSF:
+          cmd.append("--calSF=%s"%(calSF))
     if CalPhase:
       cmd.append("--CalPhase=%s"%(CalPhase))
     if chMin:
       cmd.append("--chMin=%s"%(chMin))
     if chMax:
       cmd.append("--chMax=%s"%(chMax))
-#    if calSF:
-#      cmd.append("--calSF=%s"%(calSF))
     pass
   elif tool == "trimChamber.py":
     scanType = "trim"
@@ -211,7 +212,7 @@ if __name__ == '__main__':
   envCheck('BUILD_HOME')
 
   startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
-#  print "startTime upon declaration: ", startTime
+
   if options.tool not in ["trimChamber.py","ultraThreshold.py","ultraLatency.py","fastLatency.py","ultraScurve.py"]:
     print "Invalid tool specified"
     exit(1)
@@ -240,10 +241,18 @@ if __name__ == '__main__':
                          [options.throttle for x in range(len(chamber_config))],
                          [options.internal for x in range(len(chamber_config))],
                          [options.debug for x in range(len(chamber_config))]
+                         [options.calSF for x in range(len(chamber_config))]
+                         [options.chMin for x in range(len(chamber_config))]
+                         [options.chMax for x in range(len(chamber_config))]
+                         [options.pDel for x in range(len(chamber_config))]
+                         [options.voltageStepPulse for x in range(len(chamber_config))]
+                         [options.latency for x in range(len(chamber_config))]
+                         [options.CalPhase for x in range(len(chamber_config))]
+
                          )
             )
   if options.series:
-#    print "Running jobs in serial mode"
+    print "Running jobs in serial mode"
     for link in chamber_config.keys():
       vfatMask = chamber_vfatMask[link]
       launch([ options.tool,

--- a/run_scans.py
+++ b/run_scans.py
@@ -21,7 +21,7 @@ def launchArgs(tool, cardName, shelf, link, vfatmask, scanmin, scanmax, nevts, s
   #Build Commands
   setupCmds = []
   preCmd = None
-  cmd = ["%s"%(tool),"--cardName=%s"%(cardName),"-g%s"%(link),"--L1Atime=%s"%(l1atime), "--mspl=%s"%(mspl),"--nevts=%s"%(nevts), "--vfatmask=0x%x"%(vfatmask), "--pulseDelay=%s"%(pulseDelay), "--scanmin=%s"%(scanmin), "--scanmax=%s"%(scanmax), "--ztrim=%s"%(ztrim),  "--stepSize=%s"%(stepSize)]
+  cmd = ["%s"%(tool),"--cardName=%s"%(cardName),"-g%i"%(link),"--L1Atime=%i"%(l1atime), "--mspl=%i"%(mspl),"--nevts=%i"%(nevts), "--vfatmask=0x%x"%(vfatmask), "--pulseDelay=%i"%(pulseDelay), "--scanmin=%i"%(scanmin), "--scanmax=%i"%(scanmax), "--ztrim=%f"%(ztrim),  "--stepSize=%i"%(stepSize)]
   if debug:
     cmd.append( "--debug")
   if tool == "ultraScurve.py":
@@ -36,19 +36,19 @@ def launchArgs(tool, cardName, shelf, link, vfatmask, scanmin, scanmax, nevts, s
     cmd.append( "--latency=%s"%(latency))
     preCmd = ["confChamber.py","--cardName=%s"%(cardName),"-g%i"%(link),"--zeroChan"]
     if vt1 in range(256):
-      preCmd.append("--vt1=%s"%(vt1))
+      preCmd.append("--vt1=%i"%(vt1))
       pass
     if voltageStepPulse:
       cmd.append("--voltageStepPulse")
     else:
         if calSF:
-          cmd.append("--calSF=%s"%(calSF))
+          cmd.append("--calSF=%i"%(calSF))
     if CalPhase:
-      cmd.append("--CalPhase=%s"%(CalPhase))
+      cmd.append("--CalPhase=%i"%(CalPhase))
     if chMin:
-      cmd.append("--chMin=%s"%(chMin))
+      cmd.append("--chMin=%i"%(chMin))
     if chMax:
-      cmd.append("--chMax=%s"%(chMax))
+      cmd.append("--chMax=%i"%(chMax))
     pass
   elif tool == "trimChamber.py":
     scanType = "trim"
@@ -114,7 +114,7 @@ def launchArgs(tool, cardName, shelf, link, vfatmask, scanmin, scanmax, nevts, s
     dirPath = dirPath+startTime
     preCmd = ["confChamber.py","--cardName=%s"%(cardName),"-g%i"%(link),"--zeroChan"]
     if vt1 in range(256):
-      preCmd.append("--vt1=%s"%(vt1))
+      preCmd.append("--vt1=%i"%(vt1))
       pass
     cmd.append( "--filename=%s/LatencyScanData.root"%dirPath )
     cmd.append( "--scanmin=%i"%(scanmin) )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The run_scans.py tool can now be used in series mode to execute ultraLatency.py and ultraScurve.py. The start time of the scan is taken in __main__ and then passed to the launchArgs function. Using this start time, a directory is created and named with the start time in the appropriate location which is where the scan data is put.
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
This begins to add functionality to run_scans.py, which has potential to be useful to do all kinds of scans but previously was not functional.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this by doing a Latency scan on the integration stand. First, the chamber was configured with:

(py2.7)[bstone@gem904daq01 src]$ confChamber.py -c eagle64 -g0 --run --vt1=100 --zeroChan

then run_scans.py was executed with the following:

```(py2.7)[bstone@gem904daq01 src]$ run_scans.py --tool=ultraLatency.py -c eagle64 -g0 --L1Atime=250 --mspl=3 --pulseDelay=40 --scanmin=1 --scanmax=255 --stepSize=1 --internal --voltageStepPulse --series```

The script puts the data in the directory ```/data/bigdisk/GEM-Data-Taking/GE11_QC8/GE11-X-S-CERN-0003/latency/trk/current/```, where ```current``` is a soft link to the directory created when the script is called, in this case ```current -> 2018.07.31.16.25```.

Once entering the ```current``` directory, I execute ```anaUltraLatency.py -i LatencyScanData.root```.

A screenshot of the VFAT0 latency scan is shown below.

More importantly, run_scans can now be used to take Scurves, and it will also automatically configure the chamber before running ```ultraScurve.py```. An example call to do this would be:

```run_scans.py --tool=ultraScurve.py -ceagle26 -g0 --L1Atime=250 --mspl=3 --pulseDelay=40 --voltageStepPulse --scanmin=0 --scanmax=255 --latency=27 --series --config --vt1=80```

This command will first configure the chamber with the ```vt1``` value and then run ```ultraScurve.py``` with the appropriate inputs.

The output, as well as a scan log, will be placed in a directory on the NAS according to the chamber specified in one's ```chamberInfo.py``` script and the start time of the Scurve scan.

### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/26880226/43467007-0f5c5052-94e1-11e8-9f1d-a3ac88791382.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
