### PR TITLE
New Feature: temperature monitoring [V3]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,14 +47,15 @@ preprpm: default
 	@echo "Running preprpm target"
 	@cp -rf config/scriptlets/installrpm.sh pkg/
 	$(MakeDir) $(ScriptDir)
+	@cp -rf conf*.py       $(ScriptDir)
+	@cp -rf fastLatency.py $(ScriptDir)
+	@cp -rf monitorTemperatures.py $(ScriptDir)
 	@cp -rf run_scans.py   $(ScriptDir)
 	@cp -rf sbitThreshScanParallel.py $(ScriptDir)
 	@cp -rf sbitThreshScanSeries.py $(ScriptDir)
 	@cp -rf trimChamber.py $(ScriptDir)
 	@cp -rf trimChamberV3.py $(ScriptDir)
-	@cp -rf fastLatency.py $(ScriptDir)
 	@cp -rf ultra*.py      $(ScriptDir)
-	@cp -rf conf*.py       $(ScriptDir)
 	-cp -rf README.md LICENSE CHANGELOG.md MANIFEST.in requirements.txt $(PackageDir)
 	-cp -rf README.md LICENSE CHANGELOG.md MANIFEST.in requirements.txt pkg
 

--- a/monitorTemperatures.py
+++ b/monitorTemperatures.py
@@ -1,0 +1,75 @@
+#!/bin/env python
+
+if __name__ == '__main__':
+    """
+    Script to readout and record temperatures of the electronics
+    By: Brian Dorney (brian.l.dorney@cern.ch)
+    """
+
+    # create the parser
+    import argparse
+    parser = argparse.ArgumentParser(description="Reads and records temperature of electronics.  Will read in distinct time intervals until a keyboard interrupt (Ctrl+C) is sent")
+
+    # Positional arguments
+    from reg_utils.reg_interface.common.reg_xml_parser import parseInt
+    parser.add_argument("cardName", type=str, help="hostname of the AMC you are connecting too, e.g. 'eagle64'; if running on an AMC use 'local' instead", metavar="cardName")
+    parser.add_argument("ohMask", type=parseInt, help="ohMask to apply, a 1 in the n^th bit indicates the n^th OH should be considered", metavar="ohMask")
+
+    # Optional arguments
+    parser.add_argument("-d","--debug", action="store_true", dest="debug",
+            hep = "Print additional debugging information")
+    parser.add_argument("--extRefADC", action="store_true", dest="extRefADC",
+            help = "Use externally referenced ADC to monitor temperature values on VFAT3s")
+    parser.add_argument("--extTempVFAT", action="store_true", dest="extTempVFAT",
+            help = "Use external PT1000 temperature sensors on the VFAT3 hybrid instead of the temperature sensor inside the ASIC. Note only available in HV3b_V3 hybrids or later")
+    parser.add_argument("-f","--filename", type=str, dest="filename", default="TemperatureData.root",
+            help = "Specify output filename",metavar="filename")
+    parser.add_argument("--timeInterval", type=int, dest="timeInterval", default=60,
+            help ="Time interval, in seconds, to wait in between temperature reads",metavar="timeInterval")
+    #parser.add_argument("--vfatmask", type="int", dest="vfatmask", default=0x0,
+    #              help="24 bit number where a 1 in the N^th bit indicates to mask the N^th VFAT", metavar="vfatmask")
+    args = parser.parse_args()
+
+    import ROOT as r
+    filename = options.filename
+    myF = r.TFile(filename,'recreate')
+    
+    import subprocess,datetime,time
+    startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
+    print(startTime)
+    Date = startTime
+    
+    amcBoard = HwAMC(args.cardName, args.debug)
+    print('opened connection')
+
+    import os
+    if amcBoard.fwVersion < 3:
+        print("temperature monitoring of v2b electronics is not supported, exiting!!!")
+        exit(os.EX_USAGE)
+
+    #mask = options.vfatmask
+
+    # Configure DAC Monitoring
+    tempSelect = 37
+    if args.extTempVFAT:
+        tempSelect = 38
+    amcBoard.configureVFAT3DacMonitorMulti(tempSelect, args.ohMask)
+
+    from sleep import time
+    from ctypes import *
+    adcDataMultiLinks = (c_uint32 * 24 * 12)()
+    try:
+        # place holder
+        print("Reading and recording temperature data, press Ctrl+C to stop")
+        while(True):
+            # Read all ADCs
+            rpcResp = amcBoard.readADCsMulti(adcDataMultiLinks, args.extRefADC, args.ohMask)
+
+            if rpcResp != 0:
+                raise Exception("RPC response was non-zero, reading all VFAT ADCs from OH's in ohMask = {0} failed".format(hex(args.ohMask)))
+
+            # Wait 
+            sleep(args.time)
+            pass
+    except KeyboardInterrupt:
+        # Done

--- a/monitorTemperatures.py
+++ b/monitorTemperatures.py
@@ -78,10 +78,10 @@ if __name__ == '__main__':
     origSCAMonOffVal = amcBoard.readRegister("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")
     from reg_utils.reg_interface.common.jtag import disableJtag, enableJtag, initJtagRegAddrs, jtagCommand
     initJtagRegAddrs()
-    enableJtag(args.ohMask,2)
+    #enableJtag(args.ohMask,2)
     #enableJtag(args.ohMask,5)
     #enableJtag(args.ohMask,10)
-    #enableJtag(args.ohMask,20)
+    enableJtag(args.ohMask,20)
 
     # This must come after enableJtag() otherwise Monitoring will be disabled
     print("Enabling SCA Monitoring")
@@ -102,21 +102,18 @@ if __name__ == '__main__':
             # Read all ADCs
             print("Reading Internally Referenced ADC data")
             rpcResp = amcBoard.readADCsMultiLink(adcDataIntRefMultiLinks, False, args.ohMask, args.debug)
-            print("Internally Referenced ADC Data was read")
 
             if rpcResp != 0:
                 raise Exception("RPC response was non-zero, reading all VFAT ADCs from OH's in ohMask = {0} failed".format(hex(args.ohMask)))
 
             print("Reading Externally Referenced ADC data")
             rpcResp = amcBoard.readADCsMultiLink(adcDataExtRefMultiLinks, True, args.ohMask, args.debug)
-            print("Externally Referenced ADC Data was read")
 
             if rpcResp != 0:
                 raise Exception("RPC response was non-zero, reading all VFAT ADCs from OH's in ohMask = {0} failed".format(hex(args.ohMask)))
 
             print("Reading SCA Temperatures")
             scaMonData = amcBoard.scaMonitorMultiLink(ohMask=args.ohMask)
-            print("SCA Temperatures Have Been Read")
 
             print("Reading FPGA Core Temperature")
             ohList = getOHlist(args.ohMask)

--- a/monitorTemperatures.py
+++ b/monitorTemperatures.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
 
     # create the parser
     import argparse
-    parser = argparse.ArgumentParser(description="Reads and records temperature of electronics.  Will read in distinct time intervals until a keyboard interrupt (Ctrl+C) is sent")
+    parser = argparse.ArgumentParser(description="Reads and records temperature of electronics.  If the --filename argument is not specified a single read will be performed then this script will exit.  If the --filename argument is provided this script will read in user specified time intervals until a keyboard interrupt (Ctrl+C) is sent")
 
     # Positional arguments
     from reg_utils.reg_interface.common.reg_xml_parser import parseInt
@@ -26,11 +26,11 @@ if __name__ == '__main__':
     parser.add_argument("--extTempVFAT", action="store_true", dest="extTempVFAT",
             help = "Use external PT1000 temperature sensors on the VFAT3 hybrid instead of the temperature sensor inside the ASIC. Note only available in HV3b_V3 hybrids or later")
     parser.add_argument("-f","--filename", type=str, dest="filename", default=None,
-            help = "Specify output filename",metavar="filename")
+            help = "Specify output filename to store data in.  Will cause successive reads to be performed",metavar="filename")
     parser.add_argument("--noOHs", action="store_true", dest="noOHs",
-            help = "Do not print OH temperatures to terminal; they are still read and stored in the output file if provided")
+            help = "Do not print OH temperatures to terminal; if --filename is provided OH temperatures are still read and stored in the output file")
     parser.add_argument("--noVFATs", action="store_true", dest="noVFATs",
-            help = "Do not print VFAT temperatures to terminal; they are still read and stored in the output file if provided")
+            help = "Do not print VFAT temperatures to terminal; if --filename isp provided VFAT temperatures are still read and stored in the output file")
     parser.add_argument("-t","--timeInterval", type=int, dest="timeInterval", default=60,
             help ="Time interval, in seconds, to wait in between temperature reads",metavar="timeInterval")
     args = parser.parse_args()

--- a/monitorTemperatures.py
+++ b/monitorTemperatures.py
@@ -3,6 +3,11 @@
 if __name__ == '__main__':
     """
     Script to readout and record temperatures of the electronics
+
+    If no filename option (e.g. -f, --filename) is specified a single read of all temperatures will be performed; then the program will exit.
+    Otherwise the program will read temperatures every --timeInterval seconds and print the results to an output file.
+    This will continue indefinitely until a keyboardInterrupt is issued.
+
     By: Brian Dorney (brian.l.dorney@cern.ch)
     """
 
@@ -17,28 +22,79 @@ if __name__ == '__main__':
 
     # Optional arguments
     parser.add_argument("-d","--debug", action="store_true", dest="debug",
-            hep = "Print additional debugging information")
-    parser.add_argument("--extRefADC", action="store_true", dest="extRefADC",
-            help = "Use externally referenced ADC to monitor temperature values on VFAT3s")
+            help = "Print additional debugging information")
     parser.add_argument("--extTempVFAT", action="store_true", dest="extTempVFAT",
             help = "Use external PT1000 temperature sensors on the VFAT3 hybrid instead of the temperature sensor inside the ASIC. Note only available in HV3b_V3 hybrids or later")
-    parser.add_argument("-f","--filename", type=str, dest="filename", default="TemperatureData.root",
+    parser.add_argument("-f","--filename", type=str, dest="filename", default=None,
             help = "Specify output filename",metavar="filename")
-    parser.add_argument("--timeInterval", type=int, dest="timeInterval", default=60,
+    parser.add_argument("-t","--timeInterval", type=int, dest="timeInterval", default=60,
             help ="Time interval, in seconds, to wait in between temperature reads",metavar="timeInterval")
-    #parser.add_argument("--vfatmask", type="int", dest="vfatmask", default=0x0,
-    #              help="24 bit number where a 1 in the N^th bit indicates to mask the N^th VFAT", metavar="vfatmask")
     args = parser.parse_args()
 
-    import ROOT as r
-    filename = options.filename
-    myF = r.TFile(filename,'recreate')
-    
-    import subprocess,datetime,time
-    startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
-    print(startTime)
-    Date = startTime
-    
+    if args.filename is not None:
+        import ROOT as r
+        filename = args.filename
+        outF = r.TFile(filename,'recreate')
+
+        outTreeOH = r.TTree("OHTemperatureData","OH Temperature Data as a function of time")
+        outTreeVFAT = r.TTree("VFATTemperatureData","VFAT Temperature Data as a function of time")
+
+        from array import array
+
+        # Shared Branches
+        timeYear = array('i', [0])
+        outTreeOH.Branch( 'timeYear', timeYear, 'timeYear/I' )
+        outTreeVFAT.Branch( 'timeYear', timeYear, 'timeYear/I' )
+
+        timeMonth = array('i', [0])
+        outTreeVFAT.Branch( 'timeMonth', timeMonth, 'timeMonth/I' )
+        outTreeOH.Branch( 'timeMonth', timeMonth, 'timeMonth/I' )
+
+        timeDay = array('i', [0])
+        outTreeOH.Branch( 'timeDay', timeDay, 'timeDay/I' )
+        outTreeVFAT.Branch( 'timeDay', timeDay, 'timeDay/I' )
+
+        timeHour = array('i', [0])
+        outTreeOH.Branch( 'timeHour', timeHour, 'timeHour/I' )
+        outTreeVFAT.Branch( 'timeHour', timeHour, 'timeHour/I' )
+
+        timeMinute = array('i', [0])
+        outTreeOH.Branch( 'timeMinute', timeMinute, 'timeMinute/I' )
+        outTreeVFAT.Branch( 'timeMinute', timeMinute, 'timeMinute/I' )
+
+        timeSecond = array('i', [0])
+        outTreeOH.Branch( 'timeSecond', timeSecond, 'timeSecond/I' )
+        outTreeVFAT.Branch( 'timeSecond', timeSecond, 'timeSecond/I' )
+
+        link = array('i', [0])
+        outTreeOH.Branch( 'link', link, 'link/I')
+        outTreeVFAT.Branch( 'link', link, 'link/I')
+
+        # OH Specific Branches
+        scaTemp = array('i', [0])
+        outTreeOH.Branch('scaTemp',link, 'scaTemp/I')
+
+        fpgaCoreTemp = array('f', [0])
+        outTreeOH.Branch('fpgaCoreTemp',fpgaCoreTemp,'fpgaCoreTemp/F')
+
+        ohBoardTemp = array('i', [ 0 for x in range(1,10) ])
+        for boardTemp in range(1,10):
+            outTreeOH.Branch(
+                    "ohBoardTemp{0}".format(boardTemp),
+                    ohBoardTemp[boardTemp-1],
+                    "ohBoardTemp{0}/I".format(boardTemp))
+
+        # VFAT Specific Branches
+        vfatN = array('i', [0])
+        outTreeVFAT.Branch( 'vfatN', vfatN, 'vfatN/I' )
+
+        adcTempIntRef = array('i', [0])
+        outTreeVFAT.Branch( 'adcTempIntRef', adcTempIntRef, 'adcTempIntRef/I')
+
+        adcTempExtRef = array('i', [0])
+        outTreeVFAT.Branch( 'adcTempExtRef', adcTempExtRef, 'adcTempExtRef/I')
+
+    from gempython.tools.amc_user_functions_xhal import *
     amcBoard = HwAMC(args.cardName, args.debug)
     print('opened connection')
 
@@ -47,29 +103,162 @@ if __name__ == '__main__':
         print("temperature monitoring of v2b electronics is not supported, exiting!!!")
         exit(os.EX_USAGE)
 
-    #mask = options.vfatmask
+    #print("Getting VFAT Mask for All Links")
+    #ohVFATMaskArray = amcBoard.getMultiLinkVFATMask(args.ohMask)
 
     # Configure DAC Monitoring
+    print("configuring VFAT ADCs for temperature monitoring")
     tempSelect = 37
     if args.extTempVFAT:
         tempSelect = 38
     amcBoard.configureVFAT3DacMonitorMulti(tempSelect, args.ohMask)
+    print("VFAT ADCs have been configured for temperature monitoring")
 
-    from sleep import time
+    # Remove this once a register for monitoring FPGA Core Temp Exists
+    print("Configuring SCA JTAG Registers")
+    origSCAMonOffVal = amcBoard.readRegister("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF")
+    from reg_utils.reg_interface.common.jtag import disableJtag, enableJtag, initJtagRegAddrs, jtagCommand
+    initJtagRegAddrs()
+    enableJtag(args.ohMask,2)
+
+    # This must come after enableJtag() otherwise Monitoring will be disabled
+    print("Enabling SCA Monitoring")
+    amcBoard.scaMonitorToggle(~args.ohMask & 0xFF)
+    print("SCA Monitoring Enabled, set to {0}".format(str(hex(~args.ohMask & 0xFF)).strip('L')))
+
+    from time import sleep
+    import datetime
     from ctypes import *
-    adcDataMultiLinks = (c_uint32 * 24 * 12)()
+    adcDataIntRefMultiLinks = (c_uint32 * (24 * 12))()
+    adcDataExtRefMultiLinks = (c_uint32 * (24 * 12))()
     try:
         # place holder
         print("Reading and recording temperature data, press Ctrl+C to stop")
+
+        from reg_utils.reg_interface.common.sca_utils import getOHlist
+        from reg_utils.reg_interface.common.virtex6 import Virtex6Instructions
         while(True):
+            currentTime = datetime.datetime.now()
+
             # Read all ADCs
-            rpcResp = amcBoard.readADCsMulti(adcDataMultiLinks, args.extRefADC, args.ohMask)
+            print("Reading Internally Referenced ADC data")
+            rpcResp = amcBoard.readADCsMultiLink(adcDataIntRefMultiLinks, False, args.ohMask, args.debug)
+            print("Internally Referenced ADC Data was read")
 
             if rpcResp != 0:
                 raise Exception("RPC response was non-zero, reading all VFAT ADCs from OH's in ohMask = {0} failed".format(hex(args.ohMask)))
 
+            print("Reading Externally Referenced ADC data")
+            rpcResp = amcBoard.readADCsMultiLink(adcDataExtRefMultiLinks, True, args.ohMask, args.debug)
+            print("Externally Referenced ADC Data was read")
+
+            if rpcResp != 0:
+                raise Exception("RPC response was non-zero, reading all VFAT ADCs from OH's in ohMask = {0} failed".format(hex(args.ohMask)))
+
+            print("Reading SCA Temperatures")
+            scaMonData = amcBoard.scaMonitorMultiLink(ohMask=args.ohMask)
+            print("SCA Temperatures Have Been Read")
+
+            print("Reading FPGA Core Temperature")
+            ohList = getOHlist(args.ohMask)
+            jtagCommand(True, Virtex6Instructions.SYSMON, 10, 0x04000000, 32, False)
+            adc1 = jtagCommand(False, None, 0, 0x04010000, 32, ohList)
+            jtagCommand(True, Virtex6Instructions.BYPASS, 10, None, 0, False)
+
+            print("VFAT Raw Temperature Data in ADC Counts")
+            print("| ohN | vfatN | Int ADC Val | Ext ADC Val |")
+            print("| :-: | :---: | :---------: | :---------: |")
+            for ohN in range(0,12):
+                if( not ((args.ohMask >> ohN) & 0x1)):
+                    continue
+                for vfat in range(0,24):
+                    idx = ohN * 24 + vfat
+                    print("| {0} | {1} | {2} | {3} |".format(
+                        ohN,
+                        vfat,
+                        adcDataIntRefMultiLinks[idx],
+                        adcDataExtRefMultiLinks[idx]))
+                    pass
+                pass
+
+            print("Optohybrid Temperature Data, in ADC Counts unless noted otherwise")
+            headingTxt = "| ohN | FPGA Core (deg C) | SCA Temp |"
+            headingLine= "| :-: | :---------------: | :------: |"
+            for boardTemp in range(1,10):
+                headingTxt += " Board Temp {0} |".format(boardTemp)
+                headingLine+= " :----------: |"
+            print(headingTxt)
+            print(headingLine)
+            for ohN in range(0,12):
+                if( not ((args.ohMask >> ohN) & 0x1)):
+                    continue
+                row = "| {0} | {1} | {2} |".format(
+                        ohN,
+                        #scaMonData[ohN].ohFPGACoreTemp,
+                        ((adc1[ohN] >> 6) & 0x3FF) * 503.975 / 1024.0-273.15, # Remove once dedicated register exists
+                        scaMonData[ohN].scaTemp)
+                for boardTemp in range(1,10):
+                    row += " {0} |".format(scaMonData[ohN].ohBoardTemp[boardTemp-1])
+                print(row)
+
+            if(args.filename is None):
+                break
+            else:
+                timeYear = currentTime.year
+                timeMonth = currentTime.month
+                timeDay = currentTime.day
+                timeHour = currentTime.hour
+                timeMinute = currentTime.minute
+                for ohN in range(0,12):
+                    if( not ((args.ohMask >> ohN) & 0x1)):
+                        continue
+                    for vfat in range(0,24):
+                        idx = ohN * 24 + vfat
+                        link = ohN
+                        vfatN = vfat
+                        adcTempIntRef = adcDataIntRefMultiLinks[idx]
+                        adcTempExtRef = adcDataExtRefMultiLinks[idx]
+                        outTreeVFAT.Fill()
+                        pass
+                    pass
+
+                for ohN in range(0,12):
+                    if( not ((args.ohMask >> ohN) & 0x1)):
+                        continue
+                    link = ohN
+                    #fpgaCoreTemp = scaMonData[ohN].ohFPGACoreTemp
+                    fpgaCoreTemp = ((adc1[ohN] >> 6) & 0x3FF) * 503.975 / 1024.0-273.15, # Remove once dedicated register exists
+                    scaTemp = scaMonData[ohN].scaTemp
+                    for boardTemp in range(1,10):
+                        ohBoardTemp = scaMonData[ohN].ohBoardTemp[boardTemp-1]
+                    outTreeOH.Fill()
+
+                outTreeOH.AutoSave("SaveSelf")
+                outTreeVFAT.AutoSave("SaveSelf")
+
             # Wait 
-            sleep(args.time)
+            sleep(args.timeInterval)
             pass
     except KeyboardInterrupt:
-        # Done
+        print("Finished Monitoring Temperatures")
+        pass
+    except Exception as e:
+        if args.filename is not None:
+            outTreeOH.AutoSave("SaveSelf")
+            outTreeVFAT.AutoSave("SaveSelf")
+        print "An exception occurred", e
+    finally:
+        if args.filename is not None:
+            outF.cd()
+            outTreeOH.Write()
+            outTreeVFAT.Write()
+            outF.Close()
+
+    print("Reverting SCA Monitoring To Original Value")
+    amcBoard.scaMonitorToggle(origSCAMonOffVal)
+    print("SCA Monitoring Reverted to {0}".format(str(hex(origSCAMonOffVal)).strip('L')))
+
+    disableJtag()
+
+    # Done
+    print "Done"

--- a/treeStructure.py
+++ b/treeStructure.py
@@ -203,10 +203,6 @@ class  gemTemepratureVFATTree(gemGenericTree):
         simplicity.
         """
 
-        #self.assignBaseValues(kwargs)
-        #gemGenericTree.assignBaseValues(self,kwargs)
-        #gemGenericTree.assignBaseValues(kwargs)
-
         if "adcTempIntRef" in kwargs:
             self.adcTempIntRef[0] = kwargs["adcTempIntRef"]
         if "adcTempExtRef" in kwargs:
@@ -232,18 +228,44 @@ class  gemTemepratureOHTree(gemGenericTree):
 
         gemGenericTree.__init__(self,name=name,description=description)
 
+        #self.ohBoardTemp = array('i', [ 0 for x in range(1,10) ])
+        #for boardTemp in range(1,10):
+        #    self.gemTree.Branch(
+        #            "ohBoardTemp{0}".format(boardTemp),
+        #            self.ohBoardTemp[boardTemp-1],
+        #            "ohBoardTemp{0}/I".format(boardTemp))
+        self.ohBoardTemp1 = array('f', [0])
+        self.gemTree.Branch('ohBoardTemp1',self.ohBoardTemp1,'ohBoardTemp1/F')
+
+        self.ohBoardTemp2 = array('f', [0])
+        self.gemTree.Branch('ohBoardTemp2',self.ohBoardTemp2,'ohBoardTemp2/F')
+
+        self.ohBoardTemp3 = array('f', [0])
+        self.gemTree.Branch('ohBoardTemp3',self.ohBoardTemp3,'ohBoardTemp3/F')
+
+        self.ohBoardTemp4 = array('f', [0])
+        self.gemTree.Branch('ohBoardTemp4',self.ohBoardTemp4,'ohBoardTemp4/F')
+
+        self.ohBoardTemp5 = array('f', [0])
+        self.gemTree.Branch('ohBoardTemp5',self.ohBoardTemp5,'ohBoardTemp5/F')
+
+        self.ohBoardTemp6 = array('f', [0])
+        self.gemTree.Branch('ohBoardTemp6',self.ohBoardTemp6,'ohBoardTemp6/F')
+
+        self.ohBoardTemp7 = array('f', [0])
+        self.gemTree.Branch('ohBoardTemp7',self.ohBoardTemp7,'ohBoardTemp7/F')
+
+        self.ohBoardTemp8 = array('f', [0])
+        self.gemTree.Branch('ohBoardTemp8',self.ohBoardTemp8,'ohBoardTemp8/F')
+
+        self.ohBoardTemp9 = array('f', [0])
+        self.gemTree.Branch('ohBoardTemp9',self.ohBoardTemp9,'ohBoardTemp9/F')
+
         self.scaTemp = array('f', [0])
         self.gemTree.Branch('scaTemp',self.scaTemp, 'scaTemp/F')
 
         self.fpgaCoreTemp = array('f', [0])
         self.gemTree.Branch('fpgaCoreTemp',self.fpgaCoreTemp,'fpgaCoreTemp/F')
-
-        self.ohBoardTemp = array('i', [ 0 for x in range(1,10) ])
-        for boardTemp in range(1,10):
-            self.gemTree.Branch(
-                    "ohBoardTemp{0}".format(boardTemp),
-                    self.ohBoardTemp[boardTemp-1],
-                    "ohBoardTemp{0}/I".format(boardTemp))
 
         return
 
@@ -256,10 +278,27 @@ class  gemTemepratureOHTree(gemGenericTree):
         simplicity.
         """
 
-        #self.assignBaseValues(kwargs)
-        #gemGenericTree.assignBaseValues(self,kwargs)
-        #gemGenericTree.assignBaseValues(kwargs)
-
+        #for boardTemp in range(1,10):
+        #    if "ohBoardTemp{0}".format(boardTemp) in kwargs:
+        #        self.ohBoardTemp[boardTemp-1] = kwargs["ohBoardTemp{0}".format(boardTemp)]
+        if "ohBoardTemp1" in kwargs:
+            self.ohBoardTemp1[0] = kwargs["ohBoardTemp1"]
+        if "ohBoardTemp2" in kwargs:
+            self.ohBoardTemp2[0] = kwargs["ohBoardTemp2"]
+        if "ohBoardTemp3" in kwargs:
+            self.ohBoardTemp3[0] = kwargs["ohBoardTemp3"]
+        if "ohBoardTemp4" in kwargs:
+            self.ohBoardTemp4[0] = kwargs["ohBoardTemp4"]
+        if "ohBoardTemp5" in kwargs:
+            self.ohBoardTemp5[0] = kwargs["ohBoardTemp5"]
+        if "ohBoardTemp6" in kwargs:
+            self.ohBoardTemp6[0] = kwargs["ohBoardTemp6"]
+        if "ohBoardTemp7" in kwargs:
+            self.ohBoardTemp7[0] = kwargs["ohBoardTemp7"]
+        if "ohBoardTemp8" in kwargs:
+            self.ohBoardTemp8[0] = kwargs["ohBoardTemp8"]
+        if "ohBoardTemp9" in kwargs:
+            self.ohBoardTemp9[0] = kwargs["ohBoardTemp9"]
         if "fpgaCoreTemp" in kwargs:
             self.fpgaCoreTemp[0] = kwargs["fpgaCoreTemp"]
         if "link" in kwargs:
@@ -272,10 +311,6 @@ class  gemTemepratureOHTree(gemGenericTree):
             self.vfatID[0] = kwargs["vfatID"]
         if "vfatN" in kwargs:
             self.vfatN[0] = kwargs["vfatN"]
-
-        for boardTemp in range(1,10):
-            if "boardTemp{0}".format(boardTemp) in kwargs:
-                self.ohBoardTemp[boardTemp-1] = kwargs["boardTemp{0}".format(boardTemp)]
 
         self.gemTree.Fill()
         return

--- a/treeStructure.py
+++ b/treeStructure.py
@@ -43,7 +43,33 @@ class gemGenericTree(object):
 
     def getMode(self):
         return self.mode[0]
-    
+
+    def __assignBaseValues(self, **kwargs):
+        """
+        Assigns values to the arrays defined in gemTree.__init__().
+        Does not fill the tree.
+
+        The keyword is assumed to the same as the variable name for
+        simplicity.
+        """
+
+        if "link" in kwargs:
+            self.link[0] = kwargs["link"]
+        if "Nev" in kwargs:
+            self.Nev[0] = kwargs["Nev"]
+        if "utime" in kwargs:
+            self.utime[0] = kwargs["utime"]
+        if (("vfatCH" in kwargs) and (not self.isGblDac)):
+            self.vfatCH[0] = kwargs["vfatCH"]
+        if "vfatID" in kwargs:
+            self.vfatID[0] = kwargs["vfatID"]
+        if "vfatN" in kwargs:
+            self.vfatN[0] = kwargs["vfatN"]
+        if "ztrim" in kwargs:
+            self.ztrim[0] = kwargs["ztrim"]
+
+        return
+
     def setDefaults(self, options, time):
         """
         Takes as input the options object returned by OptParser.parse_args()
@@ -149,6 +175,89 @@ class gemDacCalTreeStructure(gemGenericTree):
             if "func_dacFit" in kwargs:
                 #self.func_dacFit = kwargs["func_dacFit"].Clone()
                 kwargs["func_dacFit"].Copy(self.func_dacFit)
+
+        self.gemTree.Fill()
+        return
+
+class  gemTemepratureVFATTree(gemGenericTree):
+    def __init__(self,name="VFATTemperatureData",description="VFAT Temperature Data as a function of time"):
+        """
+        name        TName of the TTree
+        description Phrase describing the TTree
+        """
+
+        gemGenericTree.__init__(self,name=name,description=description)
+
+        self.adcTempIntRef = array('i', [0])
+        self.gemTree.Branch( 'adcTempIntRef', adcTempIntRef, 'adcTempIntRef/I')
+
+        self.adcTempExtRef = array('i', [0])
+        self.gemTree.Branch( 'adcTempExtRef', adcTempExtRef, 'adcTempExtRef/I')
+
+        return
+
+    def fill(self, **kwargs):
+        """
+        Updates the values stored in the arrays gemTree's branchs map to,
+        then it fills the tree.
+
+        The keyword is assumed to the same as the variable name for
+        simplicity.
+        """
+
+        self.__assignBaseValues(kwargs)
+
+        if "adcTempIntRef" in kwargs:
+            self.adcTempIntRef[0] = kwargs["adcTempIntRef"]
+        if "adcTempExtRef" in kwargs:
+            self.adcTempExtRef[0] = kwargs["adcTempExtRef"]
+
+        self.gemTree.Fill()
+        return
+
+class  gemTemepratureOHTree(gemGenericTree):
+    def __init__(self,name="OHTemperatureData",description="OH Temperature Data as a function of time"):
+        """
+        name        TName of the TTree
+        description Phrase describing the TTree
+        """
+
+        gemGenericTree.__init__(self,name=name,description=description)
+
+        self.scaTemp = array('i', [0])
+        self.gemTree.Branch('scaTemp',link, 'scaTemp/I')
+
+        self.fpgaCoreTemp = array('f', [0])
+        self.gemTree.Branch('fpgaCoreTemp',fpgaCoreTemp,'fpgaCoreTemp/F')
+
+        self.ohBoardTemp = array('i', [ 0 for x in range(1,10) ])
+        for boardTemp in range(1,10):
+            self.gemTree.Branch(
+                    "ohBoardTemp{0}".format(boardTemp),
+                    self.ohBoardTemp[boardTemp-1],
+                    "ohBoardTemp{0}/I".format(boardTemp))
+
+        return
+
+    def fill(self, **kwargs):
+        """
+        Updates the values stored in the arrays gemTree's branchs map to,
+        then it fills the tree.
+
+        The keyword is assumed to the same as the variable name for
+        simplicity.
+        """
+
+        self.__assignBaseValues(kwargs)
+
+        if "scaTemp" in kwargs:
+            self.scaTemp[0] = kwargs["scaTemp"]
+        if "fpgaCoreTemp" in kwargs:
+            self.fpgaCoreTemp[0] = kwargs["fpgaCoreTemp"]
+
+        for boardTemp im range(1,10):
+            if "boardTemp{0}".format(boardTemp) in kwargs:
+                self.ohBoardTemp[boardTemp-1] = kwargs["boardTemp{0}".format(boardTemp)]
 
         self.gemTree.Fill()
         return

--- a/treeStructure.py
+++ b/treeStructure.py
@@ -21,7 +21,7 @@ class gemGenericTree(object):
         self.gemTree.Branch( 'Nev', self.Nev, 'Nev/I' )
         
         self.utime = array( 'i', [ 0 ] )
-        self.gemTree.Branch( 'utime', self.utime, 'utime/I' )
+        self.gemTree.Branch( 'utime', self.utime, 'utime/i' )
         
         self.ztrim = array( 'f', [ 0 ] )
         self.gemTree.Branch( 'ztrim', self.ztrim, 'ztrim/F' )
@@ -29,8 +29,8 @@ class gemGenericTree(object):
         self.vfatCH = array( 'i', [ 0 ] )
         self.gemTree.Branch( 'vfatCH', self.vfatCH, 'vfatCH/I' )
         
-        self.vfatID = array( 'i', [-1] )
-        self.gemTree.Branch( 'vfatID', self.vfatID, 'vfatID/I' ) #Hex Chip ID of VFAT
+        self.vfatID = array( 'l', [-1] )
+        self.gemTree.Branch( 'vfatID', self.vfatID, 'vfatID/l' ) #Hex Chip ID of VFAT
 
         self.vfatN = array( 'i', [ -1 ] )
         self.gemTree.Branch( 'vfatN', self.vfatN, 'vfatN/I' )
@@ -44,7 +44,7 @@ class gemGenericTree(object):
     def getMode(self):
         return self.mode[0]
 
-    def __assignBaseValues(self, **kwargs):
+    def assignBaseValues(self, **kwargs):
         """
         Assigns values to the arrays defined in gemTree.__init__().
         Does not fill the tree.
@@ -59,8 +59,6 @@ class gemGenericTree(object):
             self.Nev[0] = kwargs["Nev"]
         if "utime" in kwargs:
             self.utime[0] = kwargs["utime"]
-        if (("vfatCH" in kwargs) and (not self.isGblDac)):
-            self.vfatCH[0] = kwargs["vfatCH"]
         if "vfatID" in kwargs:
             self.vfatID[0] = kwargs["vfatID"]
         if "vfatN" in kwargs:
@@ -189,10 +187,10 @@ class  gemTemepratureVFATTree(gemGenericTree):
         gemGenericTree.__init__(self,name=name,description=description)
 
         self.adcTempIntRef = array('i', [0])
-        self.gemTree.Branch( 'adcTempIntRef', adcTempIntRef, 'adcTempIntRef/I')
+        self.gemTree.Branch( 'adcTempIntRef', self.adcTempIntRef, 'adcTempIntRef/I')
 
         self.adcTempExtRef = array('i', [0])
-        self.gemTree.Branch( 'adcTempExtRef', adcTempExtRef, 'adcTempExtRef/I')
+        self.gemTree.Branch( 'adcTempExtRef', self.adcTempExtRef, 'adcTempExtRef/I')
 
         return
 
@@ -205,12 +203,22 @@ class  gemTemepratureVFATTree(gemGenericTree):
         simplicity.
         """
 
-        self.__assignBaseValues(kwargs)
+        #self.assignBaseValues(kwargs)
+        #gemGenericTree.assignBaseValues(self,kwargs)
+        #gemGenericTree.assignBaseValues(kwargs)
 
         if "adcTempIntRef" in kwargs:
             self.adcTempIntRef[0] = kwargs["adcTempIntRef"]
         if "adcTempExtRef" in kwargs:
             self.adcTempExtRef[0] = kwargs["adcTempExtRef"]
+        if "link" in kwargs:
+            self.link[0] = kwargs["link"]
+        if "utime" in kwargs:
+            self.utime[0] = kwargs["utime"]
+        if "vfatID" in kwargs:
+            self.vfatID[0] = kwargs["vfatID"]
+        if "vfatN" in kwargs:
+            self.vfatN[0] = kwargs["vfatN"]
 
         self.gemTree.Fill()
         return
@@ -224,11 +232,11 @@ class  gemTemepratureOHTree(gemGenericTree):
 
         gemGenericTree.__init__(self,name=name,description=description)
 
-        self.scaTemp = array('i', [0])
-        self.gemTree.Branch('scaTemp',link, 'scaTemp/I')
+        self.scaTemp = array('f', [0])
+        self.gemTree.Branch('scaTemp',self.scaTemp, 'scaTemp/F')
 
         self.fpgaCoreTemp = array('f', [0])
-        self.gemTree.Branch('fpgaCoreTemp',fpgaCoreTemp,'fpgaCoreTemp/F')
+        self.gemTree.Branch('fpgaCoreTemp',self.fpgaCoreTemp,'fpgaCoreTemp/F')
 
         self.ohBoardTemp = array('i', [ 0 for x in range(1,10) ])
         for boardTemp in range(1,10):
@@ -248,14 +256,24 @@ class  gemTemepratureOHTree(gemGenericTree):
         simplicity.
         """
 
-        self.__assignBaseValues(kwargs)
+        #self.assignBaseValues(kwargs)
+        #gemGenericTree.assignBaseValues(self,kwargs)
+        #gemGenericTree.assignBaseValues(kwargs)
 
-        if "scaTemp" in kwargs:
-            self.scaTemp[0] = kwargs["scaTemp"]
         if "fpgaCoreTemp" in kwargs:
             self.fpgaCoreTemp[0] = kwargs["fpgaCoreTemp"]
+        if "link" in kwargs:
+            self.link[0] = kwargs["link"]
+        if "scaTemp" in kwargs:
+            self.scaTemp[0] = kwargs["scaTemp"]
+        if "utime" in kwargs:
+            self.utime[0] = kwargs["utime"]
+        if "vfatID" in kwargs:
+            self.vfatID[0] = kwargs["vfatID"]
+        if "vfatN" in kwargs:
+            self.vfatN[0] = kwargs["vfatN"]
 
-        for boardTemp im range(1,10):
+        for boardTemp in range(1,10):
             if "boardTemp{0}".format(boardTemp) in kwargs:
                 self.ohBoardTemp[boardTemp-1] = kwargs["boardTemp{0}".format(boardTemp)]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This tool monitors VFAT and OH temperatures.  It can do a single one-off read, or it can read continuously every N seconds and write results to an output file.

Relevant help menu:

```bash
% monitorTemperatures.py -h                                                                                  
usage: monitorTemperatures.py [-h] [-d] [--extTempVFAT] [-f filename]
                              [--noOHs] [--noVFATs] [-t timeInterval]
                              cardName ohMask

Reads and records temperature of electronics. If the --filename argument is
not specified a single read will be performed then this script will exit. If
the --filename argument is provided this script will read in user specified
time intervals until a keyboard interrupt (Ctrl+C) is sent

positional arguments:
  cardName              hostname of the AMC you are connecting too, e.g.
                        'eagle64'; if running on an AMC use 'local' instead
  ohMask                ohMask to apply, a 1 in the n^th bit indicates the
                        n^th OH should be considered

optional arguments:
  -h, --help            show this help message and exit
  -d, --debug           Print additional debugging information
  --extTempVFAT         Use external PT1000 temperature sensors on the VFAT3
                        hybrid instead of the temperature sensor inside the
                        ASIC. Note only available in HV3b_V3 hybrids or later
  -f filename, --filename filename
                        Specify output filename to store data in. Will cause
                        successive reads to be performed
  --noOHs               Do not print OH temperatures to terminal; if
                        --filename is provided OH temperatures are still read
                        and stored in the output file
  --noVFATs             Do not print VFAT temperatures to terminal; if
                        --filename isp provided VFAT temperatures are still
                        read and stored in the output file
  -t timeInterval, --timeInterval timeInterval
                        Time interval, in seconds, to wait in between
                        temperature reads
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Need to evaluate efficiency of cooling, required tool to read all temperatures.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Testing w/single OH
Using `eagle26` with `OH2` I am able to readback the raw ADC values:

```bash
% monitorTemperatures.py -f testTemperatureData.root -t 5 eagle26 0x4
```

VFAT Raw Temperature Data in ADC Counts

| ohN | vfatN | vfatID | Int ADC Val | Ext ADC Val |
| :-: | :---: | :----: | :---------: | :---------: |
| 2 | 0 | 0x0 | 0 | 0 |
| 2 | 1 | 0xbeb | 381 | 398 |
| 2 | 2 | 0x2001101 | 425 | 439 |
| 2 | 3 | 0x0 | 0 | 0 |
| 2 | 4 | 0xbcf | 353 | 375 |
| 2 | 5 | 0x1183 | 404 | 427 |
| 2 | 6 | 0xbaf | 395 | 404 |
| 2 | 7 | 0x1106 | 397 | 416 |
| 2 | 8 | 0x110a | 365 | 384 |
| 2 | 9 | 0xbd4 | 366 | 383 |
| 2 | 10 | 0xbc1 | 361 | 378 |
| 2 | 11 | 0x0 | 0 | 0 |
| 2 | 12 | 0x1001104 | 425 | 441 |
| 2 | 13 | 0xbbd | 364 | 377 |
| 2 | 14 | 0x1107 | 380 | 393 |
| 2 | 15 | 0x4010bca | 398 | 418 |
| 2 | 16 | 0x14fe | 348 | 368 |
| 2 | 17 | 0xbbb | 378 | 398 |
| 2 | 18 | 0xc000bc6 | 393 | 406 |
| 2 | 19 | 0x10000bc4 | 357 | 372 |
| 2 | 20 | 0xbc2 | 372 | 401 |
| 2 | 21 | 0x20000f34 | 405 | 416 |
| 2 | 22 | 0x80004bb4 | 367 | 388 |
| 2 | 23 | 0xbc8 | 389 | 404 |

Optohybrid Temperature Data, in ADC Counts unless noted otherwise

| ohN | FPGA Core (deg C) | SCA Temp | Board Temp 1 | Board Temp 2 | Board Temp 3 | Board Temp 4 | Board Temp 5 | Board Temp 6 | Board Temp 7 | Board Temp 8 | Board Temp 9 |
| :-: | :---------------: | :------: | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: |
| 2 | 63.4895507813 | 3786 | 4095 | 1500 | 4095 | 3689 | 4095 | 524 | 4095 | 2608 | 4095 |

### Testing w/Multiple OH's

Using `eagle60` with `ohMask = 0x3`:

```bash
% monitorTemperatures.py -f testTemperatureData.root -t 5 eagle60 0x3
```

VFAT Raw Temperature Data in ADC Counts

| ohN | vfatN | vfatID | Int ADC Val | Ext ADC Val |
| :-: | :---: | :----: | :---------: | :---------: |
| 0 | 0 | 0x0 | 0 | 0 |
| 0 | 1 | 0x0 | 0 | 0 |
| 0 | 2 | 0x0 | 0 | 0 |
| 0 | 3 | 0x0 | 0 | 0 |
| 0 | 4 | 0x0 | 0 | 0 |
| 0 | 5 | 0x8100041 | 203 | 231 |
| 0 | 6 | 0x80044 | 193 | 227 |
| 0 | 7 | 0x4045 | 206 | 230 |
| 0 | 8 | 0x0 | 0 | 0 |
| 0 | 9 | 0x0 | 0 | 0 |
| 0 | 10 | 0x0 | 0 | 0 |
| 0 | 11 | 0x0 | 0 | 0 |
| 0 | 12 | 0x0 | 0 | 0 |
| 0 | 13 | 0x0 | 0 | 0 |
| 0 | 14 | 0x48 | 200 | 226 |
| 0 | 15 | 0x1003f | 201 | 230 |
| 0 | 16 | 0x0 | 0 | 0 |
| 0 | 17 | 0x0 | 0 | 0 |
| 0 | 18 | 0x0 | 0 | 0 |
| 0 | 19 | 0x0 | 0 | 0 |
| 0 | 20 | 0x42 | 0 | 227 |
| 0 | 21 | 0x1040 | 210 | 239 |
| 0 | 22 | 0x0 | 0 | 0 |
| 0 | 23 | 0x49 | 203 | 237 |
| 1 | 0 | 0x0 | 0 | 0 |
| 1 | 1 | 0x0 | 0 | 0 |
| 1 | 2 | 0x0 | 0 | 0 |
| 1 | 3 | 0x0 | 0 | 0 |
| 1 | 4 | 0x400000 | 197 | 225 |
| 1 | 5 | 0x0 | 199 | 228 |
| 1 | 6 | 0x0 | 198 | 224 |
| 1 | 7 | 0x0 | 203 | 232 |
| 1 | 8 | 0x0 | 0 | 0 |
| 1 | 9 | 0x0 | 0 | 0 |
| 1 | 10 | 0x0 | 0 | 0 |
| 1 | 11 | 0x0 | 0 | 0 |
| 1 | 12 | 0x1000 | 203 | 233 |
| 1 | 13 | 0x40 | 207 | 232 |
| 1 | 14 | 0x0 | 202 | 230 |
| 1 | 15 | 0x0 | 0 | 0 |
| 1 | 16 | 0x0 | 0 | 0 |
| 1 | 17 | 0x0 | 0 | 0 |
| 1 | 18 | 0x0 | 0 | 0 |
| 1 | 19 | 0x0 | 0 | 0 |
| 1 | 20 | 0x1 | 207 | 229 |
| 1 | 21 | 0x40 | 208 | 240 |
| 1 | 22 | 0x0 | 205 | 230 |
| 1 | 23 | 0x0 | 207 | 230 |

Optohybrid Temperature Data, in ADC Counts unless noted otherwise

| ohN | FPGA Core (deg C) | SCA Temp | Board Temp 1 | Board Temp 2 | Board Temp 3 | Board Temp 4 | Board Temp 5 | Board Temp 6 | Board Temp 7 | Board Temp 8 | Board Temp 9 |
| :-: | :---------------: | :------: | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: |
| 0 | -273.15 | 1648 | 4095 | 666 | 4095 | 1529 | 4095 | 2167 | 1782 | 2356 | 4095 |
| 1 | 48.7246582031 | 947 | 1416 | 2742 | 2070 | 1648 | 75 | 3957 | 3351 | 881 | 1354 |

Issues with reporting FPGA Core Temperature comes from issue FW; not a SW issue.

Note that only 12 VFATs are powered on OH1 and 8 VFATs are powered on OH0 so above matches expectation.  Please note it correctly identified the VFAT mask to use without being supplied by the user.

### Summary

The user is required to translate the ADC values to degrees Celsius still for the VFATs.  Since this calibration is unique for each VFAT.

The ADC values for the OH Board Temperature require a calibration curve for the PT1000 sensors.  This could be hard coded; but is presently not.

Validates DAC and SCA monitoring features here: https://github.com/cms-gem-daq-project/cmsgemos/pull/201

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
