### PR TITLE
[V3] Bug Fix: resolved type error in gemDacCalTreeStructure 

### DIFF
--- a/treeStructure.py
+++ b/treeStructure.py
@@ -111,14 +111,14 @@ class gemDacCalTreeStructure(gemGenericTree):
         self.dacValX = array( 'f', [0] )
         self.gemTree.Branch( 'dacValX', self.dacValX, 'dacValX/F')
 
-        self.dacValX_Err = array( 'i', [0] )
-        self.gemTree.Branch( 'dacValX_Err', self.dacValX_Err, 'dacValX_Err/I')
+        self.dacValX_Err = array( 'f', [0] )
+        self.gemTree.Branch( 'dacValX_Err', self.dacValX_Err, 'dacValX_Err/F')
 
         self.dacValY = array( 'f', [0] )
         self.gemTree.Branch( 'dacValY', self.dacValY, 'dacValY/F')
 
-        self.dacValY_Err = array( 'i', [0] )
-        self.gemTree.Branch( 'dacValY_Err', self.dacValY_Err, 'dacValY_Err/I')
+        self.dacValY_Err = array( 'f', [0] )
+        self.gemTree.Branch( 'dacValY_Err', self.dacValY_Err, 'dacValY_Err/F')
 
         self.isGblDac = isGblDac
         self.storeRoot = storeRoot


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `gemDacCalTreeStructure` should be able to handle both `int` and `float` inputs for DAC data.  However the error bar branches:

 - `dacValX_Err`, and
 - `dacValY_Err`

are defined as integers instead of floats.  For `dacScanV3.py` this doesn't pose a problem however trimChamberV3.py expects to be able to write trim (int) vs. charge (float) to these branches.  So a `TypeError` is generated when running `trimChamberV3.py`:

```
...
...
All trim points have been taken, processing
Determining trimDAC to fC Calibration
fitting trimDAC vs. scurve mean for vfat 0
Traceback (most recent call last):
  File "/opt/cmsgemos/bin/trimChamberV3.py", line 311, in <module>
    vfatN = vfat)
  File "/usr/lib/python2.7/site-packages/gempython/vfatqc/treeStructure.py", line 166, in fill
    self.dacValX_Err[0] = kwargs["dacValX_Err"]
TypeError: integer argument expected, got float
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See discussion above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I had @fraivone re-test the change and it succeeded without generating a `TypeError`.  Correspondence was done in a private PM over mattermost.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
