### PR TITLE
Bug Fix: output file permissions and KeyError

### DIFF
--- a/run_scans.py
+++ b/run_scans.py
@@ -111,7 +111,7 @@ def executeCmd(cmd, dirPath):
     except Exception as e:
         print("Caught exception: {0}".format(e))
     finally:
-        runCommand( ["chmod","-R","g+r",dirPath] )
+        runCommand( ["chmod","-R","g+rw",dirPath] )
     return
 
 def makeScanDir(ohN, scanType, startTime):
@@ -124,7 +124,10 @@ def makeScanDir(ohN, scanType, startTime):
     """
 
     from gempython.gemplotting.utils.anautilities import getDirByAnaType
-    dirPath = getDirByAnaType(scanType, chamber_config[ohN])
+    if ohN in chamber_config.keys():
+        dirPath = getDirByAnaType(scanType, chamber_config[ohN])
+    else:
+        dirPath = getDirByAnaType(scanType, "")
 
     setupCmds = [] 
     setupCmds.append( ["mkdir","-p",dirPath+"/"+startTime] )
@@ -145,16 +148,7 @@ def monitorT(args):
     
     startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
 
-    # Make output directory
-    #dirPath = "{}/temperature/".format(os.getenv("DATA_PATH"))
-    #setupCmds = [] 
-    #setupCmds.append( ["mkdir","-p",dirPath+startTime] )
-    #setupCmds.append( ["chmod","g+rw",dirPath+startTime] )
-    #setupCmds.append( ["unlink",dirPath+"current"] )
-    #setupCmds.append( ["ln","-s",startTime,dirPath+"current"] )
-    #for cmd in setupCmds:
-    #    runCommand(cmd)
-    dirPath = makeScanDir(0, "temperature", startTime)
+    dirPath = makeScanDir(-1, "temperature", startTime)
     dirPath += "/{}".format(startTime)
 
     # Build Command


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed a `KeyError` when using the `monitorT` command in `run_scans.py`.

Fixed output permissions on all commands made with `run_scan.py`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Re-ran measurements with temperature monitoring.  Did not produce a `KeyError`.
http://cmsonline.cern.ch/cms-elog/1077701

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
