### PR TITLE
Bug Fix: fixed a NameError in when reading back the comparator setting

### DIFF
--- a/confChamber.py
+++ b/confChamber.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
             if vfatBoard.parentOH.parentAMC.fwVersion > 2:
                 print 'Comparing Curently Stored VFAT Registers with %s'%options.vfatConfig
                 dict_readBack = { "vfatID":"HW_CHIP_ID", "vt1":"CFG_THR_ARM_DAC" }
-                readBackCheck(vfatTree, dict_readBack, vfatBoard, options.vfatmask, options.vt1bump)
+                readBackCheckV3(vfatTree, dict_readBack, vfatBoard, options.vfatmask, options.vt1bump)
     
         except Exception as e:
             print '%s does not seem to exist'%options.filename


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a `NameError` in the read back of the comparator setting after it has been written.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Causes a crash.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change was trivial.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
