### PR TITLE
Hotfix: testConnectivity will make directories in $DATA_PATH if they do not exist

### DIFF
--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -526,6 +526,8 @@ def testConnectivity(args):
             # If the cal file exists do nothing; otherwise write it from the DB query
             calFileADCName = "{0}/{1}/calFile_{2}_{1}.txt".format(dataPath,chamber_config[ohN],adcName)
             if not os.path.isfile(calFileADCName):
+                if not os.path.exists("{0}/{1}".format(dataPath,chamber_config[ohN])):
+                    runCommand(["mkdir", "-p", "{0}/{1}".format(dataPath,chamber_config[ohN])])
                 calFileADC = open(calFileADCName,"w")
                 calFileADC.write("vfatN/I:slope/F:intercept/F\n")
                 for idx,vfat3CalInfo in dict_vfat3CalInfo[ohN].iterrows():
@@ -653,8 +655,6 @@ def testConnectivity(args):
             try:
                 launchSCurve(
                         cardName = args.cardName,
-                        chMax = 20, #FIXME DEBUGGING REMOVE
-                        chMin = 10, #FIXME DEBUGGING REMOVE
                         debug = args.debug,
                         filename = scurveFiles[ohN],
                         link = ohN,
@@ -692,6 +692,8 @@ def testConnectivity(args):
             if os.path.isfile(calFileCALDacName):
                 calDacInfo[ohN] = parseCalFile(calFileCALDacName)
             else:
+                if not os.path.exists("{0}/{1}".format(dataPath,chamber_config[ohN])):
+                    runCommand(["mkdir", "-p", "{0}/{1}".format(dataPath,chamber_config[ohN])])
                 calFileCALDac = open(calFileCALDacName,"w")
                 calFileADC.write("vfatN/I:slope/F:intercept/F\n")
                 for idx,vfat3CalInfo in dict_vfat3CalInfo[ohN].iterrows():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The directories `${DATA_PATH}/${DETECTOR}` where not being made by `testConnectivity.py` if they did not exist when trying to perform/analyze a DAC scan or an scurve.

This caused an `IOError` to be generated when trying to open the cal file for writing. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Crashes if a new detector is tested that does not exist in `$DATA_PATH`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On QC8 DAQ machine.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
