### PR TITLE
ignoreSyncErrs flag will also ignore phase finding errors

### DIFF
--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -371,8 +371,8 @@ def testConnectivity(args):
         printGreen("Writing Found Phases to frontend")
         setPhaseAllOHs(args.cardName, dict_phases2Save, args.ohMask, nOHs, args.debug)
         vfatBoard.parentOH.parentAMC.writeRegister("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET",0x1)
-        
-        if (failed2FindGoodPhase):
+
+        if (failed2FindGoodPhase and not args.ignoreSyncErrs):
             printRed("GBT Phase Scans Failed to Find Proper Phases")
             printRed("List of Bad (OH,VFAT) pairs: {0}".format(listOfBadVFATs))
             printYellow("\tTry checking:")
@@ -381,6 +381,9 @@ def testConnectivity(args):
             printYellow("\t\t3. VDD on VFATs mentioned above is at least 1.20V")
             printRed("Connectivity Testing Failed")
             return
+        if (not failed2FindGoodPhase and args.ignoreSyncErrs):
+            printRed("Failed to find proper phases for some (OH,VFAT) pairs.")
+            printYellow("But I have been told to ignore sync errors")
         else:
             printGreen("GBT Phases Successfully Writtent to Frontend")
             pass


### PR DESCRIPTION
Apply the `ignoreSyncErrs` flag to the GBT phase finding step.

## Description
Currently, the script `testConnectivity.py` will `return` if the proper phase is not found for any of the 24 VFATs, and there is no way to mask any VFATs. So, this pull request allows the user to ignore not found phases by setting the `ignoreSyncErrs` flag.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
If some VFATs are missing from a detector, then the script will never find all 24 GBT phases and will return after the GBT phase finding step, which is not always desired.

## How Has This Been Tested?
Yes, I tested this on the coffin detector.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
