### PR TITLE
in testConnectivity.py, bias all VFATs 

### DIFF
--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -480,9 +480,12 @@ def testConnectivity(args):
             dict_vfat3CalInfo[ohN] = getVFAT3CalInfo(dict_chipIDs[ohN],debug=args.debug)
             if args.debug:
                 print("dict_vfat3CalInfo[{0}]:\n{1}".format(ohN,dict_vfat3CalInfo[ohN]))
-            
-            # Write IREF
+
+            #First, set the bias current for all VFATs to a standard value. Then, for each VFAT, check if that VFAT was found in the database. If it was found, then its bias current is replaced with the value from the database. If it was not found e.g. due to a bit flip in the chip ID, then the bias current is unchanged from the standard value.
             print("Setting CFG_IREF for all VFATs on OH{0}".format(ohN))
+            vfatBoard.biasAllVFATs(dict_vfatMask[ohN])    
+                
+
             for idx,vfat3CalInfo in dict_vfat3CalInfo[ohN].iterrows():
                 if((dict_vfatMask[ohN] >> vfat3CalInfo['vfatN']) & 0x1):
                     continue


### PR DESCRIPTION
Bias all VFATs, even the ones that are not found in the database.

## Description
A call to `vfatBoard.biasAllVFATs` is made before the loop that writes `IREF` to all VFATs with calibration information.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Currently, VFATs that are not found in the database are never biased.

## How Has This Been Tested?
Yes, it was tested in combination with https://github.com/cms-gem-daq-project/vfatqc-python-scripts/pull/235 on the coffin.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
