### PR TITLE
[Bug Fix]: String formatting in DAC scan

### DIFF
--- a/utils/scanUtils.py
+++ b/utils/scanUtils.py
@@ -89,7 +89,7 @@ def dacScanAllLinks(args, calTree, vfatBoard):
             print("| {0} | {1} | 0x{2:x} | {3} | {4} | {5} | {6} | {7} | {8} | {9} |".format(
                 calTree.link[0],
                 calTree.vfatN[0],
-                str(hex(calTree.vfatID[0])).strip('L'),
+                calTree.vfatID[0],
                 calTree.dacSelect[0],
                 calTree.nameX[0],
                 calTree.dacValX[0],


### PR DESCRIPTION
String was formatted as an integer.

## Description
`0x{2:x}` applies to integers not strings, so `vfatID` conversion to a hex string was removed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Caused DAC scan to crash when run in debug mode.

## How Has This Been Tested?
Yes, it was tested on the coffin setup.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
