### PR TITLE
[Bug Fix]: in testConnectivity.py, fix dictionary access inconsistency

### DIFF
--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -480,7 +480,7 @@ def testConnectivity(args):
             dict_vfat3CalInfo[ohN] = getVFAT3CalInfo(dict_chipIDs[ohN],debug=args.debug)
             if args.debug:
                 print("dict_vfat3CalInfo[{0}]:\n{1}".format(ohN,dict_vfat3CalInfo[ohN]))
-            
+
             # Write IREF
             print("Setting CFG_IREF for all VFATs on OH{0}".format(ohN))
             for idx,vfat3CalInfo in dict_vfat3CalInfo[ohN].iterrows():
@@ -764,10 +764,10 @@ def testConnectivity(args):
         try:
             res = pool.map_async(anaScurveParallel,
                     itertools.izip(
-                        [scurveFiles[x] for x in range(len(ohList))],
-                        [calDacInfo[x]  for x in range(len(ohList))],
-                        [deadChan       for x in range(len(ohList))],
-                        [isVFAT3        for x in range(len(ohList))]
+                        [scurveFiles[x] for x in ohList],
+                        [calDacInfo[x]  for x in ohList],
+                        [deadChan       for x in ohList],
+                        [isVFAT3        for x in ohList]
                         )
                     )
             nDeadChanByOH = res.get(3600) # wait at most 1 hour


### PR DESCRIPTION
`scurveFiles` and `calDacInfo` are created as dictionaries index by the OH number, but are accessed later as if they are lists.

## Description
This pull request corrects the way in which the entries of `scurveFiles` and `calDacInfo` are accessed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This is causing the scurve analysis to crash in `testConnectivity.py`

## How Has This Been Tested?
Yes, I tested it on the coffin detector.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
