### PR TITLE
Bug Fix: testConnectivity.py did not exit if trigger link test failed

### DIFF
--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -246,9 +246,11 @@ def testConnectivity(args):
         for trial in range(0,args.maxIter ):
             testLinks = vfatBoard.parentOH.parentAMC.getTriggerLinkStatus(printSummary=True, checkCSCTrigLink=args.checkCSCTrigLink, ohMask=args.ohMask)
 	    if (testLinks < 1):
+		fpgaCommPassed = True
                 printGreen("Trigger link to OHs in mask:{0} is good".format(hex(args.ohMask)))
                 break
             else:
+		fpgaCommPassed = False
                 printYellow("Trigger link to OHs in mask:{0} failed, retrying and issuing a reset to the trigger block of GEM_AMC".format(hex(args.ohMask)))
                 vfatBoard.parentOH.parentAMC.writeRegister("GEM_AMC.TRIGGER.CTRL.MODULE_RESET",0x1)
 
@@ -262,6 +264,9 @@ def testConnectivity(args):
             printYellow("\t\t4. Voltage on OH1 standoff is within range [0.97,1.06] Volts")
             printYellow("\t\t5. Voltage on OH2 standoff is within range [2.45,2.66] Volts")
             printYellow("\t\t6. Current limit on Power Supply is 4 Amps")
+	    printYellow("\t\t7. The trigger fibers from the optohybrid are correctly plugged into the detector patch panel")
+  	    if args.checkCSCTrigLink:
+		printYellow("\t\t8. The trigger fiber from the CSC link to the backend electronics is fully inserted to the detector patch panel")
             printRed("Connectivity Testing Failed")
             return
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Supersedes #240 

Requires: https://github.com/cms-gem-daq-project/cmsgemos/pull/269

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Skipping bad trigger links:

```bash
% testConnectivity.py -a -d --shelf=1 -s4 -o 0x4c --nPhaseScans=100 --skipDACScan --skipScurve
...
...
====================
Step 3: Programming FPGA & Checking FPGA Communication
====================
Initial value to write: 1, register GEM_AMC.TTC.GENERATOR.ENABLE
Initial value to write: 1, register GEM_AMC.TTC.GENERATOR.SINGLE_HARD_RESET
Initial value to write: 0, register GEM_AMC.TTC.GENERATOR.ENABLE
Checking trigger link status:
--=======================================--
-> GEM SYSTEM TRIGGER LINK INFORMATION
--=======================================--

----------OH2----------
LINK0_MISSED_COMMA_CNT          0xffff
LINK1_MISSED_COMMA_CNT          0xffff
LINK0_OVERFLOW_CNT              0x0
LINK1_OVERFLOW_CNT              0x0
LINK0_UNDERFLOW_CNT             0xffff
LINK1_UNDERFLOW_CNT             0xffff
LINK0_SBIT_OVERFLOW_CNT         0xffff
LINK1_SBIT_OVERFLOW_CNT         0xffff
----------OH3----------
LINK0_MISSED_COMMA_CNT          0xffff
LINK1_MISSED_COMMA_CNT          0xffff
LINK0_OVERFLOW_CNT              0x0
LINK1_OVERFLOW_CNT              0x0
LINK0_UNDERFLOW_CNT             0xffff
LINK1_UNDERFLOW_CNT             0xffff
LINK0_SBIT_OVERFLOW_CNT         0xffff
LINK1_SBIT_OVERFLOW_CNT         0xffff
----------OH6----------
LINK0_MISSED_COMMA_CNT          0xffff
LINK1_MISSED_COMMA_CNT          0xffff
LINK0_OVERFLOW_CNT              0x0
LINK1_OVERFLOW_CNT              0x0
LINK0_UNDERFLOW_CNT             0xffff
LINK1_UNDERFLOW_CNT             0xffff
LINK0_SBIT_OVERFLOW_CNT         0xffff
LINK1_SBIT_OVERFLOW_CNT         0xffff
Trigger link of OHs: [2, 3, 6] failed, but I was told to accept bad trigger links
FPGA Communication Established
```

Without skipping bad trigger links:

```bash
% testConnectivity.py -d --shelf=1 -s4 -o 0x4c --nPhaseScans=100 --skipDACScan --skipScurve
...
...
--=======================================--
-> GEM SYSTEM TRIGGER LINK INFORMATION
--=======================================--

----------OH2----------
LINK0_MISSED_COMMA_CNT          0xffff
LINK1_MISSED_COMMA_CNT          0xffff
LINK0_OVERFLOW_CNT              0x0
LINK1_OVERFLOW_CNT              0x0
LINK0_UNDERFLOW_CNT             0xffff
LINK1_UNDERFLOW_CNT             0xffff
LINK0_SBIT_OVERFLOW_CNT         0xffff
LINK1_SBIT_OVERFLOW_CNT         0xffff
----------OH3----------
LINK0_MISSED_COMMA_CNT          0xffff
LINK1_MISSED_COMMA_CNT          0xffff
LINK0_OVERFLOW_CNT              0x0
LINK1_OVERFLOW_CNT              0x0
LINK0_UNDERFLOW_CNT             0xffff
LINK1_UNDERFLOW_CNT             0xffff
LINK0_SBIT_OVERFLOW_CNT         0xffff
LINK1_SBIT_OVERFLOW_CNT         0x7d5f
----------OH6----------
LINK0_MISSED_COMMA_CNT          0xffff
LINK1_MISSED_COMMA_CNT          0xffff
LINK0_OVERFLOW_CNT              0x0
LINK1_OVERFLOW_CNT              0x0
LINK0_UNDERFLOW_CNT             0xffff
LINK1_UNDERFLOW_CNT             0xffff
LINK0_SBIT_OVERFLOW_CNT         0xffff
LINK1_SBIT_OVERFLOW_CNT         0xffff
Trigger link of OHs: [2, 3, 6] failed, retrying and issuing a reset to the trigger block of GEM_AMC
Initial value to write: 1, register GEM_AMC.TRIGGER.CTRL.MODULE_RESET
--=======================================--
-> GEM SYSTEM TRIGGER LINK INFORMATION
--=======================================--

----------OH2----------
LINK0_MISSED_COMMA_CNT          0xffff
LINK1_MISSED_COMMA_CNT          0xffff
LINK0_OVERFLOW_CNT              0x0
LINK1_OVERFLOW_CNT              0x0
LINK0_UNDERFLOW_CNT             0xffff
LINK1_UNDERFLOW_CNT             0xffff
LINK0_SBIT_OVERFLOW_CNT         0x7751
LINK1_SBIT_OVERFLOW_CNT         0xa11a
----------OH3----------
LINK0_MISSED_COMMA_CNT          0xffff
LINK1_MISSED_COMMA_CNT          0xffff
LINK0_OVERFLOW_CNT              0x0
LINK1_OVERFLOW_CNT              0x0
LINK0_UNDERFLOW_CNT             0xffff
LINK1_UNDERFLOW_CNT             0xffff
LINK0_SBIT_OVERFLOW_CNT         0xffff
LINK1_SBIT_OVERFLOW_CNT         0xcc5e
----------OH6----------
LINK0_MISSED_COMMA_CNT          0xffff
LINK1_MISSED_COMMA_CNT          0xffff
LINK0_OVERFLOW_CNT              0x0
LINK1_OVERFLOW_CNT              0x0
LINK0_UNDERFLOW_CNT             0xffff
LINK1_UNDERFLOW_CNT             0xffff
LINK0_SBIT_OVERFLOW_CNT         0xffff
LINK1_SBIT_OVERFLOW_CNT         0xffff
Trigger link of OHs: [2, 3, 6] failed, retrying and issuing a reset to the trigger block of GEM_AMC
Initial value to write: 1, register GEM_AMC.TRIGGER.CTRL.MODULE_RESET
FPGA Communication was not established successfully
Following OH's have unprogrammed FPGAs: [2, 3, 6]
        Try checking:
                1. Was the OH FW loaded into the Zynq RAM on the CTP7?
                2. OH1 and OH2 screws are properly screwed into their respective standoffs
                3. OH1 and OH2 standoffs on the GEB are not broken
                4. Voltage on OH1 standoff is within range [0.97,1.06] Volts
                5. Voltage on OH2 standoff is within range [2.45,2.66] Volts
                6. Current limit on Power Supply is 4 Amps
                7. The trigger fibers from the optohybrid are correctly plugged into the detector patch panel
Connectivity Testing Failed
Goodbye
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
