### PR TITLE
Updates to testConnectivity.py Step 3 (OH Programming & Trigger Links)

### DIFF
--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -184,7 +184,7 @@ def testConnectivity(args):
     envCheck("GBT_SETTINGS")
     
     dataPath = os.getenv('DATA_PATH')
-    gbtConfigPath = "{0}/OHv3c/20180717".format(os.getenv("GBT_SETTINGS")) # Ideally this would be a DB read...
+    gbtConfigPath = "{0}/OHv3c/20180314".format(os.getenv("GBT_SETTINGS")) # Ideally this would be a DB read...
     elogPath = os.getenv('ELOG_PATH')
 
     # Initialize Hardware
@@ -209,9 +209,9 @@ def testConnectivity(args):
 
         # Program GBTs
         gbtConfigs = [
-                "{0}/GBTX_OHv3c_GBT_0__2018-07-17_FINAL.txt".format(gbtConfigPath),
-                "{0}/GBTX_OHv3c_GBT_1__2018-07-17_FINAL.txt".format(gbtConfigPath),
-                "{0}/GBTX_OHv3c_GBT_2__2018-07-17_FINAL.txt".format(gbtConfigPath)
+                "{0}/GBTX_OHv3c_GBT_0__2018-03-14_FINAL-REG35-42.txt".format(gbtConfigPath),
+                "{0}/GBTX_OHv3c_GBT_1__2018-03-14_FINAL-REG35-42.txt".format(gbtConfigPath),
+                "{0}/GBTX_OHv3c_GBT_2__2018-03-14_FINAL-REG35-42.txt".format(gbtConfigPath),
                 ]
         print("Programming GBTs")
         configGBT(cardName=args.cardName, listOfconfigFiles=gbtConfigs, ohMask=args.ohMask, nOHs=nOHs)
@@ -279,16 +279,16 @@ def testConnectivity(args):
             if args.debug:
                 print("Trial Number: {0}".format(trial))
             
-            # Reset trigger module on CTP7 (includes counter reset)
-            print("Reseting trigger module on CTP7")
-            vfatBoard.parentOH.parentAMC.writeRegister("GEM_AMC.TRIGGER.CTRL.MODULE_RESET",0x1)
-
             # Reset trigger module on OH FPGA
             for ohN in range(nOHs):
                 if( not ((args.ohMask >> ohN) & 0x1)):
                     continue
                 print("Reset trigger module on OH{0}".format(ohN))
                 vfatBoard.parentOH.parentAMC.writeRegister("GEM_AMC.OH.OH{0}.FPGA.TRIG.LINKS.RESET".format(ohN),0x1)
+
+            # Reset trigger module on CTP7 (includes counter reset)
+            print("Reseting trigger module on CTP7")
+            vfatBoard.parentOH.parentAMC.writeRegister("GEM_AMC.TRIGGER.CTRL.MODULE_RESET",0x1)
 
             testLinks = vfatBoard.parentOH.parentAMC.getTriggerLinkStatus(
                             printSummary=True, 

--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -245,8 +245,26 @@ def testConnectivity(args):
             pass
 
         vfatBoard.parentOH.parentAMC.writeRegister("GEM_AMC.TTC.GENERATOR.ENABLE",0x0)
+        if not fpgaCommPassed:
+            printRed("FPGA Communication was not established successfully")
+            printRed("Following OH's have unprogrammed FPGAs: {0}".format(listOfDeadFPGAs))
+            printYellow("\tTry checking:")
+            printYellow("\t\t1. Was the OH FW loaded into the Zynq RAM on the CTP7?")
+            printYellow("\t\t2. OH1 and OH2 screws are properly screwed into their respective standoffs")
+            printYellow("\t\t3. OH1 and OH2 standoffs on the GEB are not broken")
+            printYellow("\t\t4. Voltage on OH1 standoff is within range [0.97,1.06] Volts")
+            printYellow("\t\t5. Voltage on OH2 standoff is within range [2.45,2.66] Volts")
+            printYellow("\t\t6. Current limit on Power Supply is 4 Amps")
+            #printYellow("\t\t7. Power Cycle the affected optohybrids")
+            printRed("Connectivity Testing Failed")
+            return
+        else:
+            printGreen("FPGA Communication Established")
+            pass
 
         print("Checking trigger link status:")
+        vfatBoard.parentOH.parentAMC.writeRegister("GEM_AMC.TRIGGER.CTRL.MODULE_RESET",0x1)
+        vfatBoard.parentOH.parentAMC.writeRegister("GEM_AMC.TRIGGER.CTRL.CNT_RESET",0x1)
         for trial in range(0,args.maxIter):
             testLinks = vfatBoard.parentOH.parentAMC.getTriggerLinkStatus(
                             printSummary=True, 
@@ -302,22 +320,16 @@ def testConnectivity(args):
             pass
 
         if not fpgaCommPassed:
-            printRed("FPGA Communication was not established successfully")
-            printRed("Following OH's have unprogrammed FPGAs: {0}".format(listOfDeadFPGAs))
+            printRed("FPGA trigger link is not healthy")
+            printRed("Following OH's have bad trigger links: {0}".format(listOfDeadFPGAs))
             printYellow("\tTry checking:")
-            printYellow("\t\t1. Was the OH FW loaded into the Zynq RAM on the CTP7?")
-            printYellow("\t\t2. OH1 and OH2 screws are properly screwed into their respective standoffs")
-            printYellow("\t\t3. OH1 and OH2 standoffs on the GEB are not broken")
-            printYellow("\t\t4. Voltage on OH1 standoff is within range [0.97,1.06] Volts")
-            printYellow("\t\t5. Voltage on OH2 standoff is within range [2.45,2.66] Volts")
-            printYellow("\t\t6. Current limit on Power Supply is 4 Amps")
-            printYellow("\t\t7. The trigger fibers from the optohybrid are correctly plugged into the detector patch panel")
+            printYellow("\t\t1. The trigger fibers from the optohybrid are correctly plugged into the detector patch panel")
             if args.checkCSCTrigLink:
-                printYellow("\t\t8. The trigger fiber from the CSC link to the backend electronics is fully inserted to the detector patch panel")
+                printYellow("\t\t2. The trigger fiber from the CSC link to the backend electronics is fully inserted to the detector patch panel")
             printRed("Connectivity Testing Failed")
             return
         else:
-            printGreen("FPGA Communication Established")
+            printGreen("Trigger Link Not Successfully Established")
             pass
     
     # Step 4

--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -267,7 +267,7 @@ def testConnectivity(args):
             printYellow("\t\t3. Voltage on OH1 standoff is within range [0.97,1.06] Volts")
             printYellow("\t\t4. Voltage on OH2 standoff is within range [2.45,2.66] Volts")
             printYellow("\t\t5. Current limit on Power Supply is 4 Amps")
-            #printYellow("\t\t6. Power Cycle the affected optohybrids")
+            printYellow("\t\t6. Power Cycle the affected optohybrids")
             printRed("Connectivity Testing Failed")
             return
         else:
@@ -350,8 +350,9 @@ def testConnectivity(args):
             printRed("Following OH's have bad trigger links: {0}".format(listOfDeadFPGAs))
             printYellow("\tTry checking:")
             printYellow("\t\t1. The trigger fibers from the optohybrid are correctly plugged into the detector patch panel")
+            printYellow("\t\t2. Power Cycle the affected optohybrids")
             if args.checkCSCTrigLink:
-                printYellow("\t\t2. The trigger fiber from the CSC link to the backend electronics is fully inserted to the detector patch panel")
+                printYellow("\t\t3. The trigger fiber from the CSC link to the backend electronics is fully inserted to the detector patch panel")
             printRed("Connectivity Testing Failed")
             return
         else:
@@ -596,6 +597,10 @@ def testConnectivity(args):
                     except Exception as e:
                         printRed("An exception has occured: {0}".format(e))
                         printRed("VFAT communication was not established successfully for OH{0} VFAT{1}".format(ohN,vfat3CalInfo['vfatN']))
+                        vfatBoard.parentOH.parentAMC.getVFATLinkStatus(doReset=False, printSummary=True, ohMask=args.ohMask)
+                        printYellow("\tTry checking:")
+                        printYellow("\t\t1. The Power Delivered on the VDD (Digital Power) to each VFAT is greater than 1.2V but does not exceed 1.35V")
+                        printYellow("\t\t2. replacing the red VFATs shown above and then running again")
                         printRed("Conncetivity Testing Failed")
                         return
                     pass
@@ -618,6 +623,10 @@ def testConnectivity(args):
             except Exception as e:
                 printRed("An exception has occured: {0}".format(e))
                 printRed("DAC Scan for DAC {0} Failed".format(maxVfat3DACSize[dacSelect]))
+                vfatBoard.parentOH.parentAMC.getVFATLinkStatus(doReset=False, printSummary=True, ohMask=args.ohMask)
+                printYellow("\tTry checking:")
+                printYellow("\t\t1. The Power Delivered on the VDD (Digital Power) to each VFAT is greater than 1.2V but does not exceed 1.35V")
+                printYellow("\t\t2. replacing the red VFATs shown above and then running again")
                 printRed("Conncetivity Testing Failed")
                 return
             pass
@@ -764,6 +773,10 @@ def testConnectivity(args):
             except Exception as e:
                 printRed("An exception has occured: {0}".format(e))
                 printRed("Failed to configure OH{0}".format(ohN))
+                vfatBoard.parentOH.parentAMC.getVFATLinkStatus(doReset=False, printSummary=True, ohMask=args.ohMask)
+                printYellow("\tTry checking:")
+                printYellow("\t\t1. The Power Delivered on the VDD (Digital Power) to each VFAT is greater than 1.2V but does not exceed 1.35V")
+                printYellow("\t\t2. replacing the red VFATs shown above and then running again")
                 printRed("Conncetivity Testing Failed")
                 return
             pass
@@ -796,6 +809,10 @@ def testConnectivity(args):
             except Exception as e:
                 printRed("An exception has occured: {0}".format(e))
                 printRed("SCurve for OH{0} Failed".format(ohN))
+                vfatBoard.parentOH.parentAMC.getVFATLinkStatus(doReset=False, printSummary=True, ohMask=args.ohMask)
+                printYellow("\tTry checking:")
+                printYellow("\t\t1. The Power Delivered on the VDD (Digital Power) to each VFAT is greater than 1.2V but does not exceed 1.35V")
+                printYellow("\t\t2. replacing the red VFATs shown above and then running again")
                 printRed("Conncetivity Testing Failed")
                 return
             pass

--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -765,7 +765,7 @@ def testConnectivity(args):
             
             ohKey = (args.shelf,args.slot,ohN)
         
-            dirPath = makeScanDir(args.slot, ohN, "scurve", startTime, args.shelf)
+            dirPath = makeScanDir(args.slot, ohN, "scurve", startTime, args.shelf, chamber_config)
             dirPath += "/{}".format(startTime)
             logFile = "%s/scanLog.log"%(dirPath)
             scurveFiles[ohN] = "{0}/{1}/scurve/{2}/SCurveData.root".format(dataPath,chamber_config[ohKey],startTime)

--- a/ultraScurve.py
+++ b/ultraScurve.py
@@ -145,7 +145,7 @@ if __name__ == '__main__':
         # Make sure no channels are receiving a cal pulse
         # This needs to be done on the CTP7 otherwise it takes an hour...
         print "stopping cal pulse to all channels"
-        vfatBoard.stopCalPulses(mask, CHAN_MIN, CHAN_MAX)
+        vfatBoard.stopCalPulses(mask, 0, 127)
     
         scanDataSizeVFAT = (options.scanmax-options.scanmin+1)/options.stepSize
         scanDataSizeNet = scanDataSizeVFAT * 24

--- a/utils/scanUtils.py
+++ b/utils/scanUtils.py
@@ -344,18 +344,21 @@ def launchSCurve(**kwargs):
     
     return
 
-def makeScanDir(slot, ohN, scanType, startTime, shelf=1):
+def makeScanDir(slot, ohN, scanType, startTime, shelf=1, chamber_config=None):
     """
     Makes a directory to store the output scan data and returns the directory path
 
     ohN - optohybrid number
     scanType - scanType, see ana_config.keys() from gempython.gemplotting.utils.anaInfo
     startTime - an instance of a datetime
+    shelf - uTCA shelf number
+    chamber_config - chamber_config dictionary
     """
 
     ohKey = (shelf,slot,ohN)
 
-    from gempython.gemplotting.mapping.chamberInfo import chamber_config
+    if chamber_config is None:
+        from gempython.gemplotting.mapping.chamberInfo import chamber_config
     from gempython.gemplotting.utils.anautilities import getDirByAnaType
     if ohKey in chamber_config.keys():
         dirPath = getDirByAnaType(scanType, chamber_config[ohKey])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Supercedes https://github.com/cms-gem-daq-project/vfatqc-python-scripts/pull/242

In addition to chamberName (described in above PR) I've changed how the system will perform FPGA programming and checking the OH trigger links based on feedback from FW engineers.

Now when checking trigger link status for each iteration it will:

- perform a trigger link reset on the CTP7 (includes a counter reset)
- perform a trigger link reset on each unmasked OH
- Check trigger link status
- If the trigger link status is not acceptable the FW of all unmasked OH's will be reloaded. 

Requires: https://github.com/cms-gem-daq-project/cmsgemos/pull/273

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Algorithm could have more reliably attempted to program OH FPGA's and check trigger links.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Extensively on the QC7 setup.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
