### PR TITLE
[(last) New Feature] legacy rpc-playground: Provided SW Tools for QC8 Shifters To Easily Update VFAT3 Config Files On CTP7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,18 +48,19 @@ preprpm: default
 	@cp -rf config/scriptlets/installrpm.sh pkg/
 	$(MakeDir) $(ScriptDir)
 	@cp -rf checkSbitMappingAndRate.py $(ScriptDir)
-	@cp -rf conf*.py       $(ScriptDir)
+	@cp -rf conf*.py $(ScriptDir)
 	@cp -rf dacScanV3.py $(ScriptDir)
 	@cp -rf fastLatency.py $(ScriptDir)
 	@cp -rf getCalInfoFromDB.py $(ScriptDir)
 	@cp -rf monitorTemperatures.py $(ScriptDir)
-	@cp -rf run_scans.py   $(ScriptDir)
+	@cp -rf run_scans.py $(ScriptDir)
 	@cp -rf sbitReadOut.py $(ScriptDir)
 	@cp -rf sbitThreshScanParallel.py $(ScriptDir)
 	@cp -rf testConnectivity.py $(ScriptDir)
 	@cp -rf trimChamber.py $(ScriptDir)
 	@cp -rf trimChamberV3.py $(ScriptDir)
-	@cp -rf ultra*.py      $(ScriptDir)
+	@cp -rf ultra*.py $(ScriptDir)
+	@cp -rf updateVFAT3ConfFiles.py $(ScriptDir)
 	-cp -rf README.md LICENSE CHANGELOG.md MANIFEST.in requirements.txt $(PackageDir)
 	-cp -rf README.md LICENSE CHANGELOG.md MANIFEST.in requirements.txt pkg
 

--- a/dacScanV3.py
+++ b/dacScanV3.py
@@ -3,15 +3,6 @@ from gempython.tools.amc_user_functions_xhal import maxVfat3DACSize
 
 import os
 
-def printDACOptions():
-    print("dac\tName")
-    print("===\t====")
-    dacOptions = maxVfat3DACSize.keys()
-    dacOptions.sort()
-    for dacVal in dacOptions:
-        print("%02d\t%s"%(dacVal,maxVfat3DACSize[dacVal][1]))
-    return
-
 if __name__ == '__main__':
     """
     Script to perform DAC scans with VFAT3
@@ -49,6 +40,7 @@ if __name__ == '__main__':
     if ((args.dacSelect not in maxVfat3DACSize.keys()) and (args.dacSelect is not None)):
         printRed("Input DAC selection {0} not understood".format(args.dacSelect))
         printRed("possible options include:")
+        from gempython.vfatqc.utils.qcutilities import printDACOptions
         printDACOptions()
         exit(os.EX_USAGE)
 

--- a/getCalInfoFromDB.py
+++ b/getCalInfoFromDB.py
@@ -6,11 +6,16 @@ if __name__ == '__main__':
     parser.add_argument("--shelf",type=int,help="uTCA shelf number",default=2)
     parser.add_argument("-s","--slot",type=int,help="AMC slot in uTCA shelf",default=5)
     parser.add_argument("-g","--gtx",type=int,help="OH on AMC slot",default=2)
+    parser.add_argument("-d","--debug",action="store_true",help="Prints additional information")
+    parser.add_argument("--write2File",action="store_true",help="If Provided data will be written to appropriate calibration files")
+    parser.add_argument("--write2CTP7",action="store_true",help="If Provided IREF data will be sent to the VFAT3 config files on the CTP7")
     args = parser.parse_args()
 
     from gempython.tools.vfat_user_functions_xhal import *
     
-    vfatBoard = HwVFAT("gem-shelf%02d-amc%02d"%(args.shelf,args.slot),args.gtx)
+    from gempython.vfatqc.utils.qcutilities import getCardName
+    cardName = getCardName(args.shelf,args.slot)
+    vfatBoard = HwVFAT(cardName,args.gtx)
 
     mask = vfatBoard.parentOH.getVFATMask()
     chipIDs = vfatBoard.getAllChipIDs(mask)
@@ -18,8 +23,9 @@ if __name__ == '__main__':
     while(len(chipIDs) != 24):
         chipIDs.append(0)
 
-    for vfat,vfatID in enumerate(chipIDs):
-        print vfat, vfatID
+    if args.debug:
+        for vfat,vfatID in enumerate(chipIDs):
+            print(vfat, vfatID)
 
     from gempython.gemplotting.utils.dbutils import getVFAT3CalInfo
     dbInfo = getVFAT3CalInfo(chipIDs)
@@ -27,6 +33,100 @@ if __name__ == '__main__':
     import pandas as pd
     pd.set_option('display.max_columns', 500)
     dbInfo.info()
-    print dbInfo
+    print(dbInfo)
+
+    if args.write2File or args.write2CTP7:
+        from gempython.gemplotting.utils.anautilities import getDataPath, getElogPath
+        ohKey = (args.shelf, args.slot, args.gtx)
+        
+        from gempython.gemplotting.mapping.chamberInfo import chamber_config
+        if ohKey in chamber_config:
+            cName = chamber_config[ohKey]
+            outDir="{0}/{1}".format(getDataPath(),chamber_config[ohKey])
+        else:
+            cName = "Detector"
+            outDir=getElogPath()
+            pass
+
+    # Write calibration info to disk?
+    if args.write2File:
+        # Write IREF Info
+        filename_iref = "{0}/NominalValues-CFG_IREF.txt".format(outDir)
+        print("Writing 'CFG_IREF' to file: {0}".format(filename_iref))
+        dbInfo.to_csv(
+                path_or_buf=filename_iref,
+                sep="\t",
+                columns=['vfatN','iref'],
+                header=False,
+                index=False,
+                mode='w')
+
+        # Write ADC0 Info
+        filename_adc0 = "{0}/calFile_ADC0_{1}.txt".format(outDir,cName)
+        print("Writing 'ADC0' Calibration file: {0}".format(filename_adc0))
+        file_adc0 = open(filename_adc0,"w")
+        file_adc0.write("vfatN/I:slope/F:intercept/F\n")
+        dbInfo.to_csv(
+                path_or_buf=file_adc0,
+                sep="\t",
+                columns=['vfatN','adc0m','adc0b'],
+                header=False,
+                index=False,
+                mode='a')
+
+        # Write CAL_DAC Info
+        filename_caldac = "{0}/calFile_calDac_{1}.txt".format(outDir,cName)
+        print("Writing 'CAL_DAC' Calibration file: {0}".format(filename_caldac))
+        file_caldac = open(filename_caldac,"w")
+        file_caldac.write("vfatN/I:slope/F:intercept/F\n")
+        dbInfo.to_csv(
+                path_or_buf=file_caldac,
+                sep="\t",
+                columns=['vfatN','cal_dacm','cal_dacb'],
+                header=False,
+                index=False,
+                mode='a')
+        pass
+
+    # Write CFG_IREF to VFAT3 Config Files On CTP7?    
+    if args.write2CTP7:
+        import os
+        from gempython.utils.wrappers import runCommand
+        filename_iref = "{0}/NominalValues-CFG_IREF.txt".format(outDir)
+        if not os.path.isfile(filename_iref):
+            filename_iref = "{0}/NominalValues-CFG_IREF.txt".format(outDir)
+            print("Writing 'CFG_IREF' to file: {0}".format(filename_iref))
+            dbInfo.to_csv(
+                    path_or_buf=filename_iref,
+                    sep="\t",
+                    columns=['vfatN','iref'],
+                    header=False,
+                    index=False,
+                    mode='w')
+            pass
+
+        gemuserHome = "/mnt/persistent/gemuser/"
+        # Copy Files
+        copyFilesCmd = [
+                'scp',
+                filename_iref,
+                'gemuser@{0}:{1}'.format(cardName,gemuserHome)
+                ]
+        runCommand(copyFilesCmd)
+
+        # Update stored vfat config
+        dacName="CFG_IREF"
+        replaceStr = "/mnt/persistent/gemdaq/scripts/replace_parameter.sh -f {0}/NominalValues-{1}.txt {2} {3}".format(
+                gemuserHome,
+                dacName,
+                dacName.replace("CFG_",""),
+                args.gtx)
+        transferCmd = [
+                'ssh',
+                'gemuser@{0}'.format(cardName),
+                'sh -c "{0}"'.format(replaceStr)
+                ]
+        runCommand(transferCmd)
+        pass
 
     print("goodbye")

--- a/getCalInfoFromDB.py
+++ b/getCalInfoFromDB.py
@@ -2,10 +2,10 @@
 
 if __name__ == '__main__':
     import argparse
-    parser = argparse.ArgumentParser(description="Queries the DB for calibration info for all VFATs on given (shelf,slot,gtx)")
-    parser.add_argument("--shelf",type=int,help="uTCA shelf number",default=2)
-    parser.add_argument("-s","--slot",type=int,help="AMC slot in uTCA shelf",default=5)
-    parser.add_argument("-g","--gtx",type=int,help="OH on AMC slot",default=2)
+    parser = argparse.ArgumentParser(description="Queries the DB for calibration info for all VFATs on given (shelf,slot,link)")
+    parser.add_argument("shelf",type=int,help="uTCA shelf number")
+    parser.add_argument("slot",type=int,help="AMC slot in uTCA shelf")
+    parser.add_argument("link",type=int,help="OH on AMC slot")
     parser.add_argument("-d","--debug",action="store_true",help="Prints additional information")
     parser.add_argument("--write2File",action="store_true",help="If Provided data will be written to appropriate calibration files")
     parser.add_argument("--write2CTP7",action="store_true",help="If Provided IREF data will be sent to the VFAT3 config files on the CTP7")
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     
     from gempython.vfatqc.utils.qcutilities import getCardName
     cardName = getCardName(args.shelf,args.slot)
-    vfatBoard = HwVFAT(cardName,args.gtx)
+    vfatBoard = HwVFAT(cardName,args.link)
 
     mask = vfatBoard.parentOH.getVFATMask()
     chipIDs = vfatBoard.getAllChipIDs(mask)
@@ -37,7 +37,7 @@ if __name__ == '__main__':
 
     if args.write2File or args.write2CTP7:
         from gempython.gemplotting.utils.anautilities import getDataPath, getElogPath
-        ohKey = (args.shelf, args.slot, args.gtx)
+        ohKey = (args.shelf, args.slot, args.link)
         
         from gempython.gemplotting.mapping.chamberInfo import chamber_config
         if ohKey in chamber_config:
@@ -116,7 +116,7 @@ if __name__ == '__main__':
         gemlogger.setLevel(logging.INFO)
     
         from gempython.vfatqc.utils.confUtils import updateVFAT3ConfFilesOnAMC
-        updateVFAT3ConfFilesOnAMC(cardName,args.gtx,filename_iref,"CFG_IREF")
+        updateVFAT3ConfFilesOnAMC(cardName,args.link,filename_iref,"CFG_IREF")
         pass
 
     print("goodbye")

--- a/getCalInfoFromDB.py
+++ b/getCalInfoFromDB.py
@@ -60,6 +60,8 @@ if __name__ == '__main__':
                 header=False,
                 index=False,
                 mode='w')
+        from gempython.utils.wrappers import runCommand
+        runCommand(["chmod", "g+rw", filename_iref])
 
         # Write ADC0 Info
         filename_adc0 = "{0}/calFile_ADC0_{1}.txt".format(outDir,cName)
@@ -73,6 +75,7 @@ if __name__ == '__main__':
                 header=False,
                 index=False,
                 mode='a')
+        runCommand(["chmod", "g+rw", filename_adc0])
 
         # Write CAL_DAC Info
         filename_caldac = "{0}/calFile_calDac_{1}.txt".format(outDir,cName)
@@ -86,12 +89,12 @@ if __name__ == '__main__':
                 header=False,
                 index=False,
                 mode='a')
+        runCommand(["chmod", "g+rw", filename_caldac])
         pass
 
     # Write CFG_IREF to VFAT3 Config Files On CTP7?    
     if args.write2CTP7:
         import os
-        from gempython.utils.wrappers import runCommand
         filename_iref = "{0}/NominalValues-CFG_IREF.txt".format(outDir)
         if not os.path.isfile(filename_iref):
             filename_iref = "{0}/NominalValues-CFG_IREF.txt".format(outDir)
@@ -103,30 +106,17 @@ if __name__ == '__main__':
                     header=False,
                     index=False,
                     mode='w')
+            from gempython.utils.wrappers import runCommand
+            runCommand(["chmod", "g+rw", filename_iref])
             pass
 
-        gemuserHome = "/mnt/persistent/gemuser/"
-        # Copy Files
-        copyFilesCmd = [
-                'scp',
-                filename_iref,
-                'gemuser@{0}:{1}'.format(cardName,gemuserHome)
-                ]
-        runCommand(copyFilesCmd)
-
-        # Update stored vfat config
-        dacName="CFG_IREF"
-        replaceStr = "/mnt/persistent/gemdaq/scripts/replace_parameter.sh -f {0}/NominalValues-{1}.txt {2} {3}".format(
-                gemuserHome,
-                dacName,
-                dacName.replace("CFG_",""),
-                args.gtx)
-        transferCmd = [
-                'ssh',
-                'gemuser@{0}'.format(cardName),
-                'sh -c "{0}"'.format(replaceStr)
-                ]
-        runCommand(transferCmd)
+        from gempython.utils.gemlogger import getGEMLogger
+        import logging
+        gemlogger = getGEMLogger(__name__)
+        gemlogger.setLevel(logging.INFO)
+    
+        from gempython.vfatqc.utils.confUtils import updateVFAT3ConfFilesOnAMC
+        updateVFAT3ConfFilesOnAMC(cardName,args.gtx,filename_iref,"CFG_IREF")
         pass
 
     print("goodbye")

--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -876,6 +876,7 @@ def testConnectivity(args):
     
         # Load DAC Values to Front-End
         from gempython.gemplotting.utils.anaInfo import nominalDacValues
+        from gempython.vfatqc.utils.confUtils import updateVFAT3ConfFilesOnAMC
         for ohN in range(nOHs):
             # Skip masked OH's
             if( not ((args.ohMask >> ohN) & 0x1)):
@@ -895,27 +896,8 @@ def testConnectivity(args):
                 elif dacName == "CFG_VREF_ADC":
                     continue
                 else:
-                    # Copy Files
-                    copyFilesCmd = [
-                            'scp',
-                            '{0}/{1}/dacScans/current/NominalValues-{2}.txt'.format(dataPath,chamber_config[ohKey],dacName),
-                            'gemuser@{0}:{1}'.format(args.cardName,gemuserHome)
-                            ]
-                    runCommand(copyFilesCmd)
-
-                    # Update stored vfat config
-                    replaceStr = "/mnt/persistent/gemdaq/scripts/replace_parameter.sh -f {0}/NominalValues-{1}.txt {2} {3}".format(
-                            gemuserHome,
-                            dacName,
-                            dacName.replace("CFG_",""),
-                            ohN)
-                    transferCmd = [
-                            'ssh',
-                            'gemuser@{0}'.format(args.cardName),
-                            'sh -c "{0}"'.format(replaceStr)
-                            ]
-                    runCommand(transferCmd)
-                    pass
+                    nomValFile='{0}/{1}/dacScans/current/NominalValues-{2}.txt'.format(dataPath,chamber_config[ohKey],dacName),
+                    updateVFAT3ConfFilesOnAMC(args.cardName,ohN,nomValFile,dacName)
                 pass
             pass
         pass

--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -1124,7 +1124,7 @@ if __name__ == '__main__':
     parser.add_argument("-f","--firstStep",type=int,help="Starting step of connectivity testing, to skip all initial steps enter '5'",default=1)
     parser.add_argument("--gemType",type=str,help="String that defines the GEM variant, available from the list: {0}".format(gemVariants.keys()),default="ge11")
     parser.add_argument("-i","--ignoreSyncErrs",action="store_true",help="Ignore VFAT Sync Errors When Checking Communication")
-    parser.add_argument("-m","--maxIter",type=int,help="Maximum number of iterations steps 2 & 3 will be attempted before failing (and exiting)",default=10)
+    parser.add_argument("-m","--maxIter",type=int,help="Maximum number of iterations steps 2 & 3 will be attempted before failing (and exiting)",default=1)
     parser.add_argument("-n","--nPhaseScans",type=int,help="Number of gbt phase scans to perform when determining vfat phase assignment",default=50)
     parser.add_argument("--skipDACScan",action="store_true",help="Do not perform any DAC Scans")
     parser.add_argument("--skipGBTPhaseScan",action="store_true",help="Do not perform any GBT Phase Scans")

--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -896,7 +896,7 @@ def testConnectivity(args):
                 elif dacName == "CFG_VREF_ADC":
                     continue
                 else:
-                    nomValFile='{0}/{1}/dacScans/current/NominalValues-{2}.txt'.format(dataPath,chamber_config[ohKey],dacName),
+                    nomValFile='{0}/{1}/dacScans/current/NominalValues-{2}.txt'.format(dataPath,chamber_config[ohKey],dacName)
                     updateVFAT3ConfFilesOnAMC(args.cardName,ohN,nomValFile,dacName)
                 pass
             pass

--- a/updateVFAT3ConfFiles.py
+++ b/updateVFAT3ConfFiles.py
@@ -1,0 +1,99 @@
+#!/bin/env python
+
+from gempython.utils.gemlogger import getGEMLogger,printRed,printYellow
+import logging
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description="Queries the DB for calibration info for all VFATs on given (shelf,slot,gtx)")
+    parser.add_argument("shelf",type=int,help="uTCA shelf number")
+    parser.add_argument("slot",type=int,help="AMC slot in uTCA shelf")
+    parser.add_argument("link",type=int,help="OH on AMC slot")
+    parser.add_argument("-d","--debug",action="store_true",help="Prints additional information")
+    parser.add_argument("--dacSelect",type=int,help="DAC selection, see VFAT3 Manual 'Table 25: GBL CFG CTR 4 : Monitoring settings', if not provided all DAC's will be sent",default=None) 
+    parser.add_argument("--scandate",type=str,help="DAC Scan scandate to use",default="current")
+
+    args = parser.parse_args()
+
+    # Set logging level to INFO if debug requested
+    if args.debug:
+        gemlogger = getGEMLogger(__name__)
+        gemlogger.setLevel(logging.INFO)
+
+    # Check to make sure (shelf,slot,key) exists in chamber_config
+    from gempython.gemplotting.mapping.chamberInfo import chamber_config
+    ohKey = (args.shelf,args.slot,args.link)
+    import os
+    if ohKey not in chamber_config:
+        printRed("I did not find (shelf,slot,link) = {0} in the chamber_config dictionary.\nExiting".format(ohKey))
+        exit(os.EX_USAGE)
+    cName = chamber_config[ohKey]
+
+    # Determine Card Name
+    from gempython.vfatqc.utils.qcutilities import getCardName
+    cardName = getCardName(args.shelf,args.slot)
+
+    from gempython.tools.hw_constants import maxVfat3DACSize
+    from gempython.gemplotting.utils.anautilities import getDataPath
+    from gempython.vfatqc.utils.confUtils import updateVFAT3ConfFilesOnAMC
+    dataPath = getDataPath()
+    if args.dacSelect is None:
+        # Send IREF values
+        filename_iref = "{0}/{1}/NominalValues-CFG_IREF.txt".format(dataPath,cName)
+        if os.path.isfile(filename_iref):
+            print("Sending CFG_IREF Information to CTP7")
+            updateVFAT3ConfFilesOnAMC(cardName,args.link,filename_iref,"CFG_IREF")
+            pass
+
+        # Send values from DAC Scan
+        for dacSelect,dacInfo in maxVfat3DACSize.iteritems():
+            dacName = dacInfo[1]
+            
+            # Skip irrelevant DAC's
+            if dacName == "CFG_CAL_DAC":
+                continue
+            elif dacName == "CFG_THR_ARM_DAC":
+                continue
+            elif dacName == "CFG_THR_ZCC_DAC":
+                continue
+            elif dacName == "CFG_VREF_ADC":
+                continue
+
+            # Check if File Exists
+            filename = "{0}/{1}/dacScans/{2}/NominalValues-{3}.txt".format(
+                    dataPath,
+                    cName,
+                    args.scandate,
+                    dacName)
+            if not os.path.isfile(filename):
+                printYellow("Nominal Values File {0} does not exist or is not readable, skipping DAC {1}".format(filename,dacName))
+                continue
+
+            print("Sending {0} Information to CTP7".format(dacName))
+            updateVFAT3ConfFilesOnAMC(cardName,args.link,filename,dacName)
+            pass
+    else:
+        if args.dacSelect not in maxVfat3DACSize.keys():
+            printRed("Input DAC selection {0} not understood".format(args.dacSelect))
+            printRed("possible options include:")
+            from gempython.vfatqc.utils.qcutilities import printDACOptions
+            printDACOptions()
+            exit(os.EX_USAGE)
+            pass
+
+        # Check if File Exists
+        dacName = maxVfat3DACSize[args.dacSelect][1]
+        filename = "{0}/{1}/dacScans/{2}/NominalValues-{3}.txt".format(
+                dataPath,
+                cName,
+                args.scandate,
+                dacName)
+        if not os.path.isfile(filename):
+            printRed("Nominal Values File {0} does not exist or is not readable.\nExiting!".format(filename))
+            exit(os.EX_USAGE)
+
+        print("Sending {0} Information to CTP7".format(dacName))
+        updateVFAT3ConfFilesOnAMC(cardName,args.link,filename,dacName)
+        pass
+
+    print("DAC Info Transferred Successfully.\nGoodbye")

--- a/utils/confUtils.py
+++ b/utils/confUtils.py
@@ -436,3 +436,38 @@ def setChannelRegisters(vfatBoard, chTree, mask, debug=False):
         pass
 
     return
+
+def updateVFAT3ConfFilesOnAMC(cardName, link, filename, dacName):
+    """
+    Updates 
+    """
+    
+    if not os.path.isfile(filename):
+        raise IOError("File {1} {0}does not exist or is not readable{1}".format(colors.READ,colors.ENDC))
+    
+    from gempython.utils.wrappers import runCommand
+    gemuserHome = "/mnt/persistent/gemuser/"
+    # Copy Files
+    copyFilesCmd = [
+            'scp',
+            filename,
+            'gemuser@{0}:{1}'.format(cardName,gemuserHome)
+            ]
+    runCommand(copyFilesCmd)
+
+    fileOnCTP7=filename.split("/")[-1]
+
+    # Update stored vfat config
+    replaceStr = "/mnt/persistent/gemdaq/scripts/replace_parameter.sh -f {0}/{1} {2} {3}".format(
+            gemuserHome,
+            fileOnCTP7,
+            dacName.replace("CFG_",""),
+            link)
+    transferCmd = [
+            'ssh',
+            'gemuser@{0}'.format(cardName),
+            'sh -c "{0}"'.format(replaceStr)
+            ]
+    runCommand(transferCmd)
+
+    return

--- a/utils/qcutilities.py
+++ b/utils/qcutilities.py
@@ -104,3 +104,17 @@ def inputOptionsValid(options, amc_major_fw_ver):
 
     # Input options are valid
     return True
+
+def printDACOptions():
+    """
+    Prints a table illustrating the correspondence of dacSelect to DAC name for VFAT3 DAC Monitoring
+    Taken from VFAT3 Manual 'Table 25: GBL CFG CTR 4 : Monitoring settings'
+    """
+    print("dac\tName")
+    print("===\t====")
+    from gempython.tools.amc_user_functions_xhal import maxVfat3DACSize
+    dacOptions = maxVfat3DACSize.keys()
+    dacOptions.sort()
+    for dacVal in dacOptions:
+        print("%02d\t%s"%(dacVal,maxVfat3DACSize[dacVal][1]))
+    return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Brief summary of changes:

- Provided utility function `updateVFAT3ConfFilesOnAMC(...)` for updating VFAT3 configuration files on the CTP7,
- Added options to `getCalInfoFromDB.py` to write calibration info to disk and transfer `CFG_IREF` info to the VFAT3 configuration files on the CTP7,
- `printDACOptions()` function moved from `dacScanV3.py` to `utils/qcutilities.py`,
- `testConnectivity.py` now uses `updateVFAT3ConfFilesOnAMC(...)` to send analyzed DAC scan settings to VFAT3 configuration file on CTP7, and
- Provided new script `updateVFAT3ConfFiles.py` to easily update the VFAT3 config files on a CTP7 based on an `ohKey` and `scandate`.

Also addresses #253 

### Changes to `getCalInfoFromDB.py`
The geographic address has been changed from optional arguments with defaults to a required input.  Two new options have been added as illustrated below:

```bash
% getCalInfoFromDB.py -h
usage: getCalInfoFromDB.py [-h] [-d] [--write2File] [--write2CTP7]
                           shelf slot link

Queries the DB for calibration info for all VFATs on given (shelf,slot,link)

positional arguments:
  shelf         uTCA shelf number
  slot          AMC slot in uTCA shelf
  link          OH on AMC slot

optional arguments:
  -h, --help    show this help message and exit
  -d, --debug   Prints additional information
  --write2File  If Provided data will be written to appropriate calibration
                files
  --write2CTP7  If Provided IREF data will be sent to the VFAT3 config files
                on the CTP7
```

If `--write2File` is supplied the following files will be created/over-written based on the DB query that was made:

- `$DATA_PATH/<Det SN>/NominalValues-CFG_IREF.txt`
- `$DAT_APTH/<Det SN>/calFile_calDac_<Det SN>.txt`
- `$DAT_APTH/<Det SN>/calFile_ADC0_<Det SN>.txt`

These files will be made with group read/write permissions.

If the `ohKey` specifying the geographic address is not found in the `chamber_config` dictionary these output files will be placed instead in `$ELOG_PATH` and `<Det SN>` will be set to the string `Detector`.

### New script `updateVFAT3ConfFiles.py`
New tool has been added for QC8 shifters to upload DAC scan data collected in QC7 to the CTP7 of interest on QC8.  This provides an easy way (one command) to update the VFAT3 configuration files on the CTP7.

Help menu:

```bash
% updateVFAT3ConfFiles.py -h
usage: updateVFAT3ConfFiles.py [-h] [-d] [--dacSelect DACSELECT]
                               [--scandate SCANDATE]
                               shelf slot link

Queries the DB for calibration info for all VFATs on given (shelf,slot,gtx)

positional arguments:
  shelf                 uTCA shelf number
  slot                  AMC slot in uTCA shelf
  link                  OH on AMC slot

optional arguments:
  -h, --help            show this help message and exit
  -d, --debug           Prints additional information
  --dacSelect DACSELECT
                        DAC selection, see VFAT3 Manual 'Table 25: GBL CFG CTR
                        4 : Monitoring settings', if not provided all DAC's
                        will be sent
  --scandate SCANDATE   DAC Scan scandate to use
```

This takes the geographic address specified by the caller and looks for a corresponding entry in the `chamber_config` dictionary.  If one is found it will then search under:

```
$DATA_PATH/chamber_config[(shelf,slot,link)]/dacScans/scandate
```

for the `NominalValues-*.txt` files.  The default `scandate` will ensure the `current` symlink'd directory is used.  If `--dacSelect` is not provided then it will:

1. Look for `$DATA_PATH/chamber_config[(shelf,slot,link)]/NominalValues-CFG_IREF.txt` and try to send this file to the CTP7 and then call `replace_parameter.sh` on the card to update the `CFG_IREF` values, then
2. For each DAC in [maxVfat3DACSize](https://github.com/cms-gem-daq-project/cmsgemos/blob/generic-amc-RPC-v3-short-term/gempython/tools/hw_constants.py#L13) it will send the nominal values file to the CTP7 and call `replace_parameter.sh` to update the VFAT3 configuration files.

Note step 2 will skip registers `CFG_CAL_DAC`, `CFG_THR_ARM_DAC`, `CFG_THR_ZCC_DAC`, and `CFG_VREF_ADC` as these are not scanned by `dacScanV3.py` or cannot be reliably determined with the internally referenced ADC in the VFAT3.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See [slides 7 & 8](https://indico.cern.ch/event/820580/contributions/3430007/attachments/1846499/3029677/BDorney_QC8_20190517.pdf) and specifically bullet points 1 & 2 of slide 8. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On the QC8 test stand.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
