### PR TITLE
Addressing Issue #259 and testConnectivity.py Detects Bad VFAT DAC Cases

### DIFF
--- a/run_scans.py
+++ b/run_scans.py
@@ -328,8 +328,13 @@ def trimChamberV3(args):
         # Additional optional arguments
         if args.armDAC is not None:
             cmd.append("--armDAC={}".format(args.armDAC))
-        if args.vfatConfig is not None:
-            cmd.append("--vfatConfig={}".format(args.vfatConfig))
+        else:
+            # Check to see if a vfatConfig exists
+            vfatConfigFile = "{0}/configs/vfatConfig_{1}.txt".format(dataPath,chamber_config[ohKey])
+            if os.path.isfile(vfatConfigFile):
+                cmd.append("--vfatConfig={}".format(vfatConfigFile))
+                pass
+            pass
 
         # Execute
         executeCmd(cmd,dirPath)
@@ -617,10 +622,11 @@ if __name__ == '__main__':
     parser_trim.add_argument("-n","--nevts",type=int,default=100,help="Number of events for each scan position")
     parser_trim.add_argument("--trimPoints", type=str,default="-63,0,63",help="comma separated list of trim values to use in trimming, a set of scurves will be taken at each point")
     parser_trim.add_argument("--vfatmask",type=parseInt,default=None,help="If specified this will use this VFAT mask for all unmasked OH's in ohMask.  Here this is a 24 bit number, where a 1 in the N^th bit means ignore the N^th VFAT.  If this argument is not specified VFAT masks are determined at runtime automatically.")
+    parser_trim.add_argument("--armDAC",type=int,help="CFG_THR_ARM_DAC value to write to all VFATs. If not provided we will look under $DATA_PATH/configs for a vfatConfig_<DetectorName>.txt file where DetectorNames are from the chamber_config dictionary")
 
-    armDacGroup = parser_trim.add_mutually_exclusive_group()
-    armDacGroup.add_argument("--armDAC",type=int,help="CFG_THR_ARM_DAC value to write to all VFATs")
-    armDacGroup.add_argument("--vfatConfig",type=str,help="Specify file containing CFG_THR_ARM_DAC settings")
+    #armDacGroup = parser_trim.add_mutually_exclusive_group()
+    #armDacGroup.add_argument("--armDAC",type=int,help="CFG_THR_ARM_DAC value to write to all VFATs")
+    #armDacGroup.add_argument("--vfatConfig",type=str,help="Specify file containing CFG_THR_ARM_DAC settings")
 
     parser_trim.set_defaults(func=trimChamberV3)
 

--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -867,8 +867,21 @@ def testConnectivity(args):
         from gempython.gemplotting.utils.anautilities import dacAnalysis
         try:
             dacAnalysis(args, calTree.gemTree, chamber_config, scandate=startTime)
+        except ValueError as e:
+            printRed("ValueError has occurred")
+            printRed(e.message)
+            printRed("DAC Scan Analysis Failed")
+            printRed("Conncetivity Testing Failed")
+            return
+        except RuntimeError as e:
+            printRed("Runtime Error has occurred")
+            printRed(e.message)
+            printRed("DAC Scan Analysis Failed")
+            printRed("Conncetivity Testing Failed")
+            return
         except Exception as e:
-            printRed("An exception has occured: {0}".format(e))
+            printRed("An unexpected exception has occured: {0}".format(e))
+            printRed(e.message)
             printRed("DAC Scan Analysis Failed")
             printRed("Conncetivity Testing Failed")
             return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addressing #259.

Additionally, `testConnectivity.py` will now detect cases where a VFAT DAC cannot reach the right bias voltage/current setting.  An option `--acceptBadDACBiases` has been provided to be able to continue even when the DACs are found to be problematic.

Requires:

 - https://github.com/cms-gem-daq-project/gem-plotting-tools/pull/215

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

The `--vfatConfig` argument has been dropped from the `trim` subcommand help menu.

Now if the user does not specify the `--armDac` option the algorithm will look under `$DATA_PATH/configs` for each unmasked OH for a file of the form `vfatConfig_<detSN>.txt`-where detSN comes from `chamber_config.values()`-exists; if it does exist this file will be passed to `trimChamberV3.py` when the call is made so that a per `vfatConfig` can be applied at the time of trimming automatically.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See #259 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested under  http://cmsonline.cern.ch/cms-elog/1085008

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
