### PR TITLE
Ignore uHAL exceptions regarding the ADC monitoring block (partially fixes #266)

### DIFF
--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -97,7 +97,12 @@ def scaCommIsGood(amc, maxIter=5, ohMask=0xfff, nOHs=12):
     from reg_utils.reg_interface.common.jtag import initJtagRegAddrs
     initJtagRegAddrs()
 
-    writeRegister(amc,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",0xffffffff)
+    try:
+        writeRegister(amc,"GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",0xffffffff)
+    except uhal._core.exception:
+        printYellow("An exception has been caught while attempting to disable the ADC monitoring.")
+        printYellow("If you use a CTP7 with a firmware version higher than 3.8.3 you can safely ignore this warning.")
+        pass
 
     for trial in range(0,maxIter):
         sca_reset(ohMask)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Any uHAL exception occurring while trying to disable the ADC monitoring block are now ignored with an explicit warning message.

This is the simplest option and has been chosen since the target branch is legacy. Moreover issues to connect to the CTP7 IPBus daemon are already caught earlier in the script. Finally all code regarding the ADC monitoring block will be removed in the future, once the firmwares will be stable. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

See issue #266.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This patch was extensively tested during GEB&OH QC at ULB with the CTP7 firmware version 3.8.5.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
