### PR TITLE
New Feature: Additional Configure Options for `confAllChambers.py`

### DIFF
--- a/confAllChambers.py
+++ b/confAllChambers.py
@@ -30,23 +30,23 @@ def launchArgs(shelf,slot,link,run,armDAC,armDACBump,configType,cName,debug=Fals
             )
 
     from gempython.utils.gemlogger import printYellow
-    if ((configType & 0x1) == 0x1):         # Set vfatConfig
+    if (configType & 0x1):          # Set vfatConfig
         vfatConfig = "{0}/configs/vfatConfig_{1}.txt".format(dataPath,cName)
 
         if os.path.isfile(vfatConfig):
             args.vfatConfig = vfatConfig
         else:
             printYellow("No vfat configuration exists for {0}".format(cName))
-    if (((configType >> 1) & 0x1) == 0x1):  # Set chConfig and potentially channel masks
+    if ( (configType & 0x2) > 0):   # Set chConfig and potentially channel masks
         chConfig = "{0}/configs/chConfig_{1}.txt".format(dataPath,cName)
 
         if os.path.isfile(chConfig):
             args.chConfig = chConfig
-            if (((configType >> 2) & 0x1) == 0x1):
+            if ( (configType & 0x4) > 0):
                 args.applyMasks = True
         else:
             printYellow("No channel configuration exists for {0}".format(cName))
-    if (((configType >> 3) & 0x1) == 0x1):  # Zero all channel registers
+    if ( (configType & 0x8) > 0):   # Zero all channel registers
         args.chConfig = None
         args.applyMasks = False
         args.zeroChan = True
@@ -95,13 +95,13 @@ if __name__ == '__main__':
     # [3] -> zero channels
     configType=0x0
     if args.vfatConfig:
-        configType += 0x1
+        configType |= 0x1
     if args.chConfig:
-        configType += (0x1 << 1)
+        configType |= 0x2
         if args.applyMasks:
-            configType += (0x1 << 2)
+            configType |= 0x4
     if args.zeroChan:
-        configType += (0x1 << 3)
+        configType |= 0x8
         pass
 
     # consider only the shelf of interest

--- a/confAllChambers.py
+++ b/confAllChambers.py
@@ -5,7 +5,7 @@ import os
 def launch(args):
   return launchArgs(*args)
 
-def launchArgs(shelf,slot,link,run,armDAC,armDACBump,config,cName,debug=False):
+def launchArgs(shelf,slot,link,run,armDAC,armDACBump,configType,cName,debug=False):
     dataPath = os.getenv('DATA_PATH')
 
     from gempython.vfatqc.utils.qcutilities import getCardName
@@ -15,6 +15,7 @@ def launchArgs(shelf,slot,link,run,armDAC,armDACBump,config,cName,debug=False):
 
     from gempython.vfatqc.utils.namespace import Namespace
     args = Namespace(
+            applyMasks = False,
             chConfig = None,
             compare = False,
             debug = debug,
@@ -28,22 +29,27 @@ def launchArgs(shelf,slot,link,run,armDAC,armDACBump,config,cName,debug=False):
             zeroChan = False
             )
 
-    if config:
-        chConfig = "{0}/configs/chConfig_{1}.txt".format(dataPath,cName)
+    from gempython.utils.gemlogger import printYellow
+    if ((configType & 0x1) == 0x1):         # Set vfatConfig
         vfatConfig = "{0}/configs/vfatConfig_{1}.txt".format(dataPath,cName)
 
-        # Channel config
-        if os.path.isfile(chConfig):
-            args.chConfig = chConfig
-        else:
-            print("No channel configuration exists for {0}".format(cName))
-        
-        # VFAT Config
         if os.path.isfile(vfatConfig):
             args.vfatConfig = vfatConfig
         else:
-            print("No vfat configuration exists for {0}".format(cName))
+            printYellow("No vfat configuration exists for {0}".format(cName))
+    if (((configType >> 1) & 0x1) == 0x1):  # Set chConfig and potentially channel masks
+        chConfig = "{0}/configs/chConfig_{1}.txt".format(dataPath,cName)
 
+        if os.path.isfile(chConfig):
+            args.chConfig = chConfig
+            if (((configType >> 2) & 0x1) == 0x1):
+                args.applyMasks = True
+        else:
+            printYellow("No channel configuration exists for {0}".format(cName))
+    if (((configType >> 3) & 0x1) == 0x1):  # Zero all channel registers
+        args.chConfig = None
+        args.applyMasks = False
+        args.zeroChan = True
         pass
 
     from gempython.utils.gemlogger import getGEMLogger
@@ -66,15 +72,37 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Tool for configuring all front-end electronics")
     parser.add_argument("--armDAC", type=int,default = 100,help="CFG_THR_ARM_DAC value to write to all VFATs")
     parser.add_argument("--armDACBump", type=int,help="CFG_THR_ARM_DAC value for all VFATs", default=0)
-    parser.add_argument("--config", action="store_true",help="Set Configuration from simple txt files")
     parser.add_argument("-d","--debug", action="store_true",help="prints additional debugging information")
     parser.add_argument("--run", action="store_true",help="Set VFATs to run mode")
     parser.add_argument("--series", action="store_true",help="Run tests in series (default is false)")
     parser.add_argument("--shelf", type=int,help="uTCA shelf number",default=1)
+
+    confGroup = parser.add_argument_group(title="Configuration Group",description="Options for configuring channel registers and CFG_THR_ARM_DAC") 
+    confGroup.add_argument("--applyMasks", action="store_true",help="If paired with --chConfig channel masks defined in chConfig text file will be applied; otherwise no effect")
+    confGroup.add_argument("--vfatConfig", action="store_true",help="Set only CFG_THR_ARM_DAC registers from symlinks found under $DATA_PATH/configs")
+    chConfGroup = confGroup.add_mutually_exclusive_group()
+    chConfGroup.add_argument("--chConfig", action="store_true",help="Set only channel registers from symlinks found under $DATA_PATH/configs")
+    chConfGroup.add_argument("--zeroChan", action="store_true",help="Zeros all channel registers")
     args = parser.parse_args()
 
     from gempython.utils.wrappers import envCheck
     envCheck('DATA_PATH')
+
+    # determine configType, 4-bit number with bit meaning as:
+    # [0] -> apply vfatConfig
+    # [1] -> apply chConfig
+    # [2] -> apply channel masks
+    # [3] -> zero channels
+    configType=0x0
+    if args.vfatConfig:
+        configType += 0x1
+    if args.chConfig:
+        configType += (0x1 << 1)
+        if args.applyMasks:
+            configType += (0x1 << 2)
+    if args.zeroChan:
+        configType += (0x1 << 3)
+        pass
 
     # consider only the shelf of interest
     from gempython.gemplotting.mapping.chamberInfo import chamber_config
@@ -94,15 +122,15 @@ if __name__ == '__main__':
     import itertools
     if args.debug:
         print list(itertools.izip(
-                        [ohKey[0]                  for ohKey in chambers2Configure],
-                        [ohKey[1]                  for ohKey in chambers2Configure],
-                        [ohKey[2]                  for ohKey in chambers2Configure],
-                        [args.run                  for ohKey in chambers2Configure],
-                        [args.armDAC               for ohKey in chambers2Configure],
-                        [args.armDACBump           for ohKey in chambers2Configure],
-                        [args.config               for ohKey in chambers2Configure],
-                        [chambers2Configure[ohKey] for ohKey in chambers2Configure.keys()],
-                        [args.debug                for ohKey in chambers2Configure.keys()]
+                        [ohKey[0]                   for ohKey in chambers2Configure],
+                        [ohKey[1]                   for ohKey in chambers2Configure],
+                        [ohKey[2]                   for ohKey in chambers2Configure],
+                        [args.run                   for ohKey in chambers2Configure],
+                        [args.armDAC                for ohKey in chambers2Configure],
+                        [args.armDACBump            for ohKey in chambers2Configure],
+                        [configType                 for ohKey in chambers2Configure],
+                        [chambers2Configure[ohKey]  for ohKey in chambers2Configure.keys()],
+                        [args.debug                 for ohKey in chambers2Configure.keys()]
                   )
             )
         pass
@@ -117,7 +145,7 @@ if __name__ == '__main__':
                     args.run,
                     args.armDAC,
                     args.armDACBump,
-                    args.config,
+                    configType,
                     chamber,
                     args.debug
                     )
@@ -135,15 +163,15 @@ if __name__ == '__main__':
         try:
             res = pool.map_async(launch,
                                  itertools.izip(
-                                    [ohKey[0]                  for ohKey in chambers2Configure],
-                                    [ohKey[1]                  for ohKey in chambers2Configure],
-                                    [ohKey[2]                  for ohKey in chambers2Configure],
-                                    [args.run                  for ohKey in chambers2Configure],
-                                    [args.armDAC               for ohKey in chambers2Configure],
-                                    [args.armDACBump           for ohKey in chambers2Configure],
-                                    [args.config               for ohKey in chambers2Configure],
-                                    [chambers2Configure[ohKey] for ohKey in chambers2Configure.keys()],
-                                    [args.debug                for ohKey in chambers2Configure.keys()]
+                                    [ohKey[0]                   for ohKey in chambers2Configure],
+                                    [ohKey[1]                   for ohKey in chambers2Configure],
+                                    [ohKey[2]                   for ohKey in chambers2Configure],
+                                    [args.run                   for ohKey in chambers2Configure],
+                                    [args.armDAC                for ohKey in chambers2Configure],
+                                    [args.armDACBump            for ohKey in chambers2Configure],
+                                    [configType                 for ohKey in chambers2Configure],
+                                    [chambers2Configure[ohKey]  for ohKey in chambers2Configure.keys()],
+                                    [args.debug                 for ohKey in chambers2Configure.keys()]
                                     )
                                  )
 

--- a/confChamber.py
+++ b/confChamber.py
@@ -17,6 +17,7 @@ if __name__ == '__main__':
     from reg_utils.reg_interface.common.reg_xml_parser import parseInt
     parser = argparse.ArgumentParser(description="Tool for configuring front-end electronics")
     
+    parser.add_argument("--applyMasks", action="store_true", help="Channel masks defined in chConfig will be applied if this option is provided; otherwise no channel masks will be set")
     parser.add_argument("--chConfig", type=str, dest="chConfig", default=None,
                       help="Specify file containing channel settings from anaUltraSCurve.py")
     parser.add_argument("--compare", action="store_true", dest="compare",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In some cases we want channel registers applied (e.g. to determine `CFG_THR_ARM_DAC` setting without hot channels throwing off the SBIT threshold measurements).  In other cases we want only `CFG_THR_ARM_DAC` applied and no channel registers applied.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Breaking because the `--config` option has been replaced by several sets of config options:

```
% confAllChambers.py -h
usage: confAllChambers.py [-h] [--armDAC ARMDAC] [--armDACBump ARMDACBUMP]
                          [-d] [--run] [--series] [--shelf SHELF]
                          [--applyMasks] [--vfatConfig]
                          [--chConfig | --zeroChan]

Tool for configuring all front-end electronics

optional arguments:
  -h, --help            show this help message and exit
  --armDAC ARMDAC       CFG_THR_ARM_DAC value to write to all VFATs
  --armDACBump ARMDACBUMP
                        CFG_THR_ARM_DAC value for all VFATs
  -d, --debug           prints additional debugging information
  --run                 Set VFATs to run mode
  --series              Run tests in series (default is false)
  --shelf SHELF         uTCA shelf number

Configuration Group:
  Options for configuring channel registers and CFG_THR_ARM_DAC

  --applyMasks          If paired with --chConfig channel masks defined in
                        chConfig text file will be applied; otherwise no
                        effect
  --vfatConfig          Set only CFG_THR_ARM_DAC registers from symlinks found
                        under $DATA_PATH/configs
  --chConfig            Set only channel registers from symlinks found under
                        $DATA_PATH/configs
  --zeroChan            Zeros all channel registers
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Need additional configuration options for working with QC8.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On the QC8 test stand.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
