### PR TITLE
add iterativeTrim.py to run_scans.py

### DIFF
--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -388,6 +388,6 @@ if __name__ == '__main__':
         pass
 
     # Store iterative trim results
-    dfTrimResults.to_csv("iterativeTrimResults.csv",header=True,index=False)
+    dfTrimResults.to_csv(dirPath + "/iterativeTrimResults.csv",header=True,index=False)
 
     print("Trimming procedure completed")

--- a/run_scans.py
+++ b/run_scans.py
@@ -338,6 +338,84 @@ def trimChamberV3(args):
 
     return
 
+def iterTrim(args):
+    """
+    Launches a call of iterativeTrim.py
+    
+    args - object returned by argparse.ArgumentParser.parse_args() 
+    """
+    
+    startTime = datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")
+    
+    # Determine number of OH's
+    cardName = getCardName(args.shelf,args.slot)
+    amcBoard = HwAMC(cardName, args.debug)
+    print('opened connection')
+
+    # Get DATA_PATH
+    dataPath = os.getenv("DATA_PATH")
+
+    for ohN in range(0,amcBoard.nOHs+1):
+        # Skip masked OH's        
+        if( not ((args.ohMask >> ohN) & 0x1)):
+            continue
+   
+        ohKey = (args.shelf,args.slot,ohN)
+        print("iterativeTrimming shelf{0} slot{1} OH{2} detector {3}".format(args.shelf,args.slot,ohN,chamber_config[ohKey]))
+        
+        # Get & make the output directory
+        dirPath = makeScanDir(args.slot, ohN, "iterTrim", startTime, args.shelf)
+
+        calDacCalFile = "{0}/{1}/calFile_calDac_{1}.txt".format(dataPath,chamber_config[ohKey])
+        calDacCalFileExists = os.path.isfile(calDacCalFile)
+        if not calDacCalFileExists:
+            print("Skipping shelf{0} slot{1} OH{2}, detector {3}, missing CFG_CAL_DAC Calibration file:\n\t{2}".format(
+                args.shelf,
+                args.slot,
+                ohN,
+                chamber_config[ohKey],
+                calDacCalFile))
+            continue
+
+        # Get base command
+        cmd = [
+                "iterativeTrim.py",
+                "{}".format(args.shelf),
+                "{}".format(args.slot),
+                "{}".format(ohN),
+                "--calFileCAL={}".format(calDacCalFile),
+                "--chMax={}".format(args.chMax),
+                "--chMin={}".format(args.chMin),
+                "--dirPath={}".format(dirPath),
+                "--latency={}".format(args.latency),
+                "--maxIter={}".format(args.maxIter),
+                "--nevts={}".format(args.nevts),
+                "--vfatmask=0x{:x}".format(args.vfatmask if (args.vfatmask is not None) else amcBoard.getLinkVFATMask(ohN) ),
+                ]
+
+        # debug flag raised?
+        if args.debug:
+            cmd.append("-d")
+        
+        # Additional optional arguments
+        if args.armDAC is not None:
+            cmd.append("--armDAC={}".format(args.armDAC))
+        else:
+            # Check to see if a vfatConfig exists
+            vfatConfigFile = "{0}/configs/vfatConfig_{1}.txt".format(dataPath,chamber_config[ohKey])
+            if os.path.isfile(vfatConfigFile):
+                cmd.append("--vfatConfig={}".format(vfatConfigFile))
+                pass
+            pass
+
+        # Execute
+        executeCmd(cmd,dirPath)
+        print("Finished iterativeTrimming shelf{0} slot{1} OH{2} detector {3}".format(args.shelf,args.slot,ohN,chamber_config[ohKey]))
+
+    print("Finished iterativeTrimming all optohybrids on shelf{0} slot{1} in ohMask: 0x{2:x}".format(args.shelf,args.slot,args.ohMask))
+
+    return
+
 def ultraLatency(args):
     """
     Launches a call of ultraLatency.py
@@ -620,7 +698,20 @@ if __name__ == '__main__':
     #armDacGroup.add_argument("--vfatConfig",type=str,help="Specify file containing CFG_THR_ARM_DAC settings")
 
     parser_trim.set_defaults(func=trimChamberV3)
+    
+    # Create subparser for iterativeTrim
+    parser_itertrim = subparserCmds.add_parser("itertrim", help="Launches a trim run using the iterativeTrim.py tool", parents = [parent_parser])
+    parser_itertrim.add_argument("--chMax",type=int,default=127,help="Specify maximum channel number to scan")
+    parser_itertrim.add_argument("--chMin",type=int,default=0,help="Specify minimum channel number to scan")
+    parser_itertrim.add_argument("-l","--latency",type=int,default=33,help="Setting of CFG_LATENCY register")
+    parser_itertrim.add_argument("--maxIter", type=int, help="Maximum number of iterations to perform (e.g. number of scurves to take)", default=4)
+    parser_itertrim.add_argument("-m","--mspl",type=int,default=3,help="Setting of CFG_PULSE_STRETCH register")
+    parser_itertrim.add_argument("-n","--nevts",type=int,default=100,help="Number of events for each scan position")
+    parser_itertrim.add_argument("--vfatmask",type=parseInt,default=None,help="If specified this will use this VFAT mask for all unmasked OH's in ohMask.  Here this is a 24 bit number, where a 1 in the N^th bit means ignore the N^th VFAT.  If this argument is not specified VFAT masks are determined at runtime automatically.")
+    parser_itertrim.add_argument("--armDAC",type=int,help="CFG_THR_ARM_DAC value to write to all VFATs. If not provided we will look under $DATA_PATH/configs for a vfatConfig_<DetectorName>.txt file where DetectorNames are from the chamber_config dictionary")
 
+    parser_itertrim.set_defaults(func=iterTrim)
+    
     # Check env
     from gempython.utils.wrappers import envCheck
     envCheck('DATA_PATH')

--- a/run_scans.py
+++ b/run_scans.py
@@ -350,7 +350,7 @@ def iterTrim(args):
     # Determine number of OH's
     cardName = getCardName(args.shelf,args.slot)
     amcBoard = HwAMC(cardName, args.debug)
-    print('opened connection')
+    print("opened connection")
 
     # Get DATA_PATH
     dataPath = os.getenv("DATA_PATH")


### PR DESCRIPTION
Add iterative trimming to run_scans

## Description
This pull request does the following three things:

1. Adds a new function in run_scans.py called iterTrim(). 
2. Adds the associated argparse block.
3. Writes `iterativeTrimResults.csv` to the specified output directory instead of the current directory.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Intended to resolve issue https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/274

## How Has This Been Tested?
Yes, testing performed on the coffin: http://cmsonline.cern.ch/cms-elog/1090077

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
