### PR TITLE
add detector name branch to all scans

### DIFF
--- a/utils/scanUtils.py
+++ b/utils/scanUtils.py
@@ -1,5 +1,6 @@
 from ctypes import *
 
+from gempython.gemplotting.mapping.chamberInfo import chamber_config
 from gempython.tools.amc_user_functions_xhal import maxVfat3DACSize
 from gempython.tools.vfat_user_functions_xhal import *
 from gempython.utils.gemlogger import printGreen
@@ -60,8 +61,8 @@ def dacScanAllLinks(args, calTree, vfatBoard):
 
     #try:
     if args.debug:
-        print("| link | vfatN | vfatID | dacSelect | nameX | dacValX | dacValX_Err | nameY | dacValY | dacValY_Err |")
-        print("| :--: | :---: | :----: | :-------: |:-----: | :-----: | :---------: | :--: | :-----: | :---------: |")
+        print("| detName | link | vfatN | vfatID | dacSelect | nameX | dacValX | dacValX_Err | nameY | dacValY | dacValY_Err |")
+        print("| :-----: | :--: | :---: | :----: | :-------: |:-----: | :-----: | :---------: | :--: | :-----: | :---------: |")
     for dacWord in scanData:
         # Get OH and skip if not in args.ohMask
         ohN  = ((dacWord >> 23) & 0xf)
@@ -79,6 +80,7 @@ def dacScanAllLinks(args, calTree, vfatBoard):
                 dacValY = ((dacWord >> 8) & 0x3ff),
                 dacValY_Err = 1, # convert to physical units in analysis, LSB is the error on Y
                 iref = irefVals[ohN][vfat],
+                detName = chamber_config[(amcBoard.getShelf(),amcBoard.getSlot(),ohN)],  
                 link = ohN,
                 shelf = amcBoard.getShelf(),
                 slot = amcBoard.getSlot(),
@@ -86,7 +88,8 @@ def dacScanAllLinks(args, calTree, vfatBoard):
                 vfatN = vfat
                 )
         if args.debug:
-            print("| {0} | {1} | 0x{2:x} | {3} | {4} | {5} | {6} | {7} | {8} | {9} |".format(
+            print("| {0} | {1} | {2} | 0x{3:x} | {4} | {5} | {6} | {7} | {8} | {9} | {10} |".format(
+                calTree.detName[0],                
                 calTree.link[0],
                 calTree.vfatN[0],
                 calTree.vfatID[0],
@@ -155,8 +158,8 @@ def dacScanSingleLink(args, calTree, vfatBoard):
 
     #try:
     if args.debug:
-        print("| link | vfatN | vfatID | dacSelect | nameX | dacValX | dacValX_Err | nameY | dacValY | dacValY_Err |")
-        print("| :--: | :---: | :----: | :-------: | :-----: | :-----: | :---------: | :--: | :-----: | :---------: |")
+        print("| detName | link | vfatN | vfatID | dacSelect | nameX | dacValX | dacValX_Err | nameY | dacValY | dacValY_Err |")
+        print("| :-----: | :--: | :---: | :----: | :-------: | :-----: | :-----: | :---------: | :--: | :-----: | :---------: |")
     for dacWord in scanData:
         vfat = (dacWord >>18) & 0x1f
         calTree.fill(
@@ -169,7 +172,8 @@ def dacScanSingleLink(args, calTree, vfatBoard):
                 vfatN = vfat
                 )
         if args.debug:
-            print("| {0} | {1} | 0x{2:x} | {3} | {4} | {5} | {6} | {7} | {8} |".format(
+            print("| {0} | {1} | {2} | 0x{3:x} | {4} | {5} | {6} | {7} | {8} | {9} |".format(
+                calTree.detName[0],                
                 calTree.link[0],
                 calTree.vfatN[0],
                 calTree.vfatID[0],
@@ -477,8 +481,8 @@ def sbitRateScanAllLinks(args, rateTree, vfatBoard, chan=128, scanReg="CFG_THR_A
 
     # place holder
     if args.debug:
-        print("| link | vfatN | vfatID | vfatCH | nameX | dacValX | rate |")
-        print("| :--: | :---: | :----: | :----: | :---: | :-----: | :--: |")
+        print("| detName | link | vfatN | vfatID | vfatCH | nameX | dacValX | rate |")
+        print("| :-----: | :--: | :---: | :----: | :----: | :---: | :-----: | :--: |")
     for ohN in range(0,amcBoard.nOHs):
         # Skip masked OH's
         if( not ((args.ohMask >> ohN) & 0x1)):
@@ -495,6 +499,7 @@ def sbitRateScanAllLinks(args, rateTree, vfatBoard, chan=128, scanReg="CFG_THR_A
                 idxDAC = ohN*nDACValues + (dacVal-args.scanmin)/args.stepSize
                 rateTree.fill(
                         dacValX = scanDataDAC[idxDAC],
+                        detName = chamber_config[(amcBoard.getShelf(),amcBoard.getSlot(),ohN)],
                         link = ohN,
                         nameX = scanReg,
                         rate = scanDataRatePerVFAT[idxVFAT],
@@ -505,7 +510,8 @@ def sbitRateScanAllLinks(args, rateTree, vfatBoard, chan=128, scanReg="CFG_THR_A
                         vfatN = vfat
                         )
                 if args.debug:
-                    print("| {0} | {1} | 0x{2:x} | {3} | {4} | {5} | {6} |".format(
+                    print("| {0} | {1} | {2} | 0x{3:x} | {4} | {5} | {6} | {7} |".format(
+                            rateTree.detName[0],                        
                             rateTree.link[0],
                             rateTree.vfatN[0],
                             rateTree.vfatID[0],
@@ -524,6 +530,7 @@ def sbitRateScanAllLinks(args, rateTree, vfatBoard, chan=128, scanReg="CFG_THR_A
             idxDAC = ohN*nDACValues + (dacVal-args.scanmin)/args.stepSize
             rateTree.fill(
                     dacValX = scanDataDAC[idxDAC],
+                    detName = chamber_config[(amcBoard.getShelf(),amcBoard.getSlot(),ohN)],
                     link = ohN,
                     nameX = scanReg,
                     rate = scanDataRate[idxDAC],
@@ -534,7 +541,8 @@ def sbitRateScanAllLinks(args, rateTree, vfatBoard, chan=128, scanReg="CFG_THR_A
                     vfatN = 24
                     )
             if args.debug:
-                print("| {0} | {1} | 0x{2:x} | {3} | {4} | {5} | {6} |".format(
+                print("| {0} | {1} | {2} | 0x{3:x} | {4} | {5} | {6} | {7} |".format(
+                        rateTree.detName[0],
                         rateTree.link[0],
                         rateTree.vfatN[0],
                         rateTree.vfatID[0],

--- a/utils/treeStructure.py
+++ b/utils/treeStructure.py
@@ -33,7 +33,7 @@ class gemGenericTree(object):
         self.gemTree.Branch( 'slot', self.slot, 'slot/I' )
 
         self.detName = r.vector('string')()
-        self.detName.push_back(detName)
+        self.detName.push_back("X-X-X-X-X")        
         self.gemTree.Branch( 'detName', self.detName)
         
         self.utime = array( 'i', [ 0 ] )

--- a/utils/treeStructure.py
+++ b/utils/treeStructure.py
@@ -31,6 +31,10 @@ class gemGenericTree(object):
 
         self.slot = array( 'i', [ 0 ] )
         self.gemTree.Branch( 'slot', self.slot, 'slot/I' )
+
+        self.detName = r.vector('string')()
+        self.detName.push_back(detName)
+        self.gemTree.Branch( 'detName', self.detName)
         
         self.utime = array( 'i', [ 0 ] )
         self.gemTree.Branch( 'utime', self.utime, 'utime/i' )
@@ -64,6 +68,8 @@ class gemGenericTree(object):
 
         if "iref" in kwargs:
             self.iref[0] = kwargs["iref"]
+        if "detName" in kwargs:
+            self.detName[0] = kwargs["detName"]            
         if "link" in kwargs:
             self.link[0] = kwargs["link"]
         if "Nev" in kwargs:
@@ -97,6 +103,10 @@ class gemGenericTree(object):
         self.slot[0] = options.slot
         self.utime[0] = time
 
+        from gempython.gemplotting.mapping.chamberInfo import chamber_config
+
+        self.detName[0] = chamber_config[(options.shelf,options.slot,options.gtx)]
+        
         return
 
     def write(self):
@@ -178,6 +188,8 @@ class gemDacCalTreeStructure(gemGenericTree):
             self.dacValY_Err[0] = kwargs["dacValY_Err"]
         if "iref" in kwargs:
             self.iref[0] = kwargs["iref"]
+        if "detName" in kwargs:
+            self.detName[0] = kwargs["detName"]
         if "link" in kwargs:
             self.link[0] = kwargs["link"]
         if "dacSelect" in kwargs:
@@ -243,6 +255,8 @@ class gemSbitRateTreeStructure(gemGenericTree):
         
         if "dacValX" in kwargs:
             self.dacValX[0] = kwargs["dacValX"]
+        if "detName" in kwargs:
+            self.detName[0] = kwargs["detName"]
         if "link" in kwargs:
             self.link[0] = kwargs["link"]
         if "nameX" in kwargs:
@@ -297,6 +311,8 @@ class gemTemepratureVFATTree(gemGenericTree):
             self.adcTempExtRef[0] = kwargs["adcTempExtRef"]
         if "iref" in kwargs:
             self.iref[0] = kwargs["iref"]
+        if "detName" in kwargs:
+            self.link[0] = kwargs["detName"]            
         if "link" in kwargs:
             self.link[0] = kwargs["link"]
         if "shelf" in kwargs:
@@ -386,6 +402,8 @@ class  gemTemepratureOHTree(gemGenericTree):
             self.ohBoardTemp9[0] = kwargs["ohBoardTemp9"]
         if "fpgaCoreTemp" in kwargs:
             self.fpgaCoreTemp[0] = kwargs["fpgaCoreTemp"]
+        if "detName" in kwargs:
+            self.link[0] = kwargs["detName"]            
         if "link" in kwargs:
             self.link[0] = kwargs["link"]
         if "scaTemp" in kwargs:
@@ -498,6 +516,8 @@ class gemTreeStructure(gemGenericTree):
             self.l1aTime[0] = kwargs["l1aTime"]
         if "latency" in kwargs:
             self.latency[0] = kwargs["latency"]
+        if "detName" in kwargs:
+            self.detName[0] = kwargs["detName"]            
         if "link" in kwargs:
             self.link[0] = kwargs["link"]
         if "pDel" in kwargs:


### PR DESCRIPTION
Adds a detector name (like `GE11-X-S-INDIA-0002`) branch to all scans.

Closes #273 

## Description
Creates a new branch that is a vector of strings and pushes back a single dummy string "X-X-X-X-X". In `setDefaults` function, import the `chamber_config` and set the detector name. Update s`dacScanAllLinks` and `sbitRateScanAllLinks` such that it sets the OH-specific detector name when it fills the output tree.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context
Intended to resolve issue https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/273

## How Has This Been Tested?
Yes, this was tested on the coffin with several scan types: http://cmsonline.cern.ch/cms-elog/1090191

### Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
