### PR TITLE
[New Feature] Variable waitTime for parallel sbitrate scans

### DIFF
--- a/run_scans.py
+++ b/run_scans.py
@@ -662,7 +662,7 @@ if __name__ == '__main__':
     parser_sbitThresh.add_argument("--scanmin",type=int,default=0,help="Minimum CFG_THR_ARM_DAC")
     parser_sbitThresh.add_argument("--scanmax",type=int,default=255,help="Maximum CFG_THR_ARM_DAC")
     parser_sbitThresh.add_argument("--stepSize",type=int,default=1,help="Step size to use when scanning CFG_THR_ARM_DAC")
-    parser_sbitThresh.add_argument("--waitTime",type=int,default=1000,help="Length of the time window within which the rate is measured, in milliseconds")
+    parser_sbitThresh.add_argument("--waitTime",type=int,default=1000,help="Length of the time window within which the rate is measured, in seconds")
     parser_sbitThresh.set_defaults(func=sbitThreshScan)
 
 

--- a/run_scans.py
+++ b/run_scans.py
@@ -662,7 +662,7 @@ if __name__ == '__main__':
     parser_sbitThresh.add_argument("--scanmin",type=int,default=0,help="Minimum CFG_THR_ARM_DAC")
     parser_sbitThresh.add_argument("--scanmax",type=int,default=255,help="Maximum CFG_THR_ARM_DAC")
     parser_sbitThresh.add_argument("--stepSize",type=int,default=1,help="Step size to use when scanning CFG_THR_ARM_DAC")
-    parser_sbitThresh.add_argument("--waitTime",type=int,default=1000,help="Length of the time window within which the rate is measured, in seconds")
+    parser_sbitThresh.add_argument("--waitTime",type=int,default=1,help="Length of the time window within which the rate is measured, in seconds")
     parser_sbitThresh.set_defaults(func=sbitThreshScan)
 
 

--- a/run_scans.py
+++ b/run_scans.py
@@ -230,6 +230,7 @@ def sbitThreshScan(args):
             "--scanmax={}".format(args.scanmax),
             "--scanmin={}".format(args.scanmin),
             "--stepSize={}".format(args.stepSize),
+            "--waitTime={}".format(args.waitTime),        
             str(args.shelf),
             str(args.slot),
             "0x{:x}".format(args.ohMask)
@@ -661,6 +662,7 @@ if __name__ == '__main__':
     parser_sbitThresh.add_argument("--scanmin",type=int,default=0,help="Minimum CFG_THR_ARM_DAC")
     parser_sbitThresh.add_argument("--scanmax",type=int,default=255,help="Maximum CFG_THR_ARM_DAC")
     parser_sbitThresh.add_argument("--stepSize",type=int,default=1,help="Step size to use when scanning CFG_THR_ARM_DAC")
+    parser_sbitThresh.add_argument("--waitTime",type=int,default=1000,help="Length of the time window within which the rate is measured, in milliseconds")
     parser_sbitThresh.set_defaults(func=sbitThreshScan)
 
 

--- a/sbitThreshScanParallel.py
+++ b/sbitThreshScanParallel.py
@@ -32,6 +32,7 @@ if __name__ == '__main__':
     parser.add_argument("--scanmin", type=int, help="Minimum value of scan parameter", default=0)
     parser.add_argument("--scanmax", type=int, help="Maximum value of scan parameter", default=255)
     parser.add_argument("--stepSize", type=int, help="Supply a step size to the scan from scanmin to scanmax", default=1)
+    parser.add_argument("--waitTime", type=int, help="Length of the time window within which the rate is measured, in milliseconds",default=1000)
     args = parser.parse_args()
     
     from gempython.utils.gemlogger import printRed, printYellow

--- a/sbitThreshScanParallel.py
+++ b/sbitThreshScanParallel.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     parser.add_argument("--scanmin", type=int, help="Minimum value of scan parameter", default=0)
     parser.add_argument("--scanmax", type=int, help="Maximum value of scan parameter", default=255)
     parser.add_argument("--stepSize", type=int, help="Supply a step size to the scan from scanmin to scanmax", default=1)
-    parser.add_argument("--waitTime", type=int, help="Length of the time window within which the rate is measured, in seconds",default=1000)
+    parser.add_argument("--waitTime", type=int, help="Length of the time window within which the rate is measured, in seconds",default=1)
     args = parser.parse_args()
     
     from gempython.utils.gemlogger import printRed, printYellow

--- a/sbitThreshScanParallel.py
+++ b/sbitThreshScanParallel.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     parser.add_argument("--scanmin", type=int, help="Minimum value of scan parameter", default=0)
     parser.add_argument("--scanmax", type=int, help="Maximum value of scan parameter", default=255)
     parser.add_argument("--stepSize", type=int, help="Supply a step size to the scan from scanmin to scanmax", default=1)
-    parser.add_argument("--waitTime", type=int, help="Length of the time window within which the rate is measured, in milliseconds",default=1000)
+    parser.add_argument("--waitTime", type=int, help="Length of the time window within which the rate is measured, in seconds",default=1000)
     args = parser.parse_args()
     
     from gempython.utils.gemlogger import printRed, printYellow

--- a/utils/scanUtils.py
+++ b/utils/scanUtils.py
@@ -472,7 +472,8 @@ def sbitRateScanAllLinks(args, rateTree, vfatBoard, chan=128, scanReg="CFG_THR_A
             chan=chan,
             dacMin=args.scanmin, 
             dacMax=args.scanmax, 
-            dacStep=args.stepSize, 
+            dacStep=args.stepSize,
+            waitTime=args.waitTime,
             ohMask=args.ohMask, 
             scanReg=scanReg)
     

--- a/utils/scanUtils.py
+++ b/utils/scanUtils.py
@@ -467,15 +467,15 @@ def sbitRateScanAllLinks(args, rateTree, vfatBoard, chan=128, scanReg="CFG_THR_A
     print("scanning {0} for all VFATs in ohMask 0x{1:x} {2}".format(scanReg,args.ohMask,strChannels))
     rpcResp = amcBoard.performSBITRateScanMultiLink(
             scanDataDAC, 
-            scanDataRate, 
-            scanDataRatePerVFAT, 
+            scanDataRate, #this is actually a rate i.e. it has units of Hz
+            scanDataRatePerVFAT, #this is actually not a rate - it is an integrated count
             chan=chan,
             dacMin=args.scanmin, 
             dacMax=args.scanmax, 
             dacStep=args.stepSize,
-            waitTime=args.waitTime,
             ohMask=args.ohMask, 
-            scanReg=scanReg)
+            scanReg=scanReg,
+            waitTime=args.waitTime)
     
     if rpcResp != 0:
         raise Exception('RPC response was non-zero, sbit rate scan failed')
@@ -503,7 +503,8 @@ def sbitRateScanAllLinks(args, rateTree, vfatBoard, chan=128, scanReg="CFG_THR_A
                         detName = chamber_config[(amcBoard.getShelf(),amcBoard.getSlot(),ohN)],
                         link = ohN,
                         nameX = scanReg,
-                        rate = scanDataRatePerVFAT[idxVFAT],
+                        #as mentioned above, scanDataRatePerVFAT is actually a count, unlike scanDateRate which is already a rate 
+                        rate = scanDataRatePerVFAT[idxVFAT]/float(args.waitTime),
                         shelf = amcBoard.getShelf(),
                         slot = amcBoard.getSlot(),
                         vfatCH = chan,
@@ -534,6 +535,7 @@ def sbitRateScanAllLinks(args, rateTree, vfatBoard, chan=128, scanReg="CFG_THR_A
                     detName = chamber_config[(amcBoard.getShelf(),amcBoard.getSlot(),ohN)],
                     link = ohN,
                     nameX = scanReg,
+                    #as mentioned above, scanDataRate is already a rate, unlike scanDataRatePerVFAT which is actually a count 
                     rate = scanDataRate[idxDAC],
                     shelf = amcBoard.getShelf(),
                     slot = amcBoard.getSlot(),


### PR DESCRIPTION
This is one of four pull requests to four repositories that make the data collection time for parallel sbitrate scans configurable.

## Description
Adds a `waitTime` argument in `run_scans.py` and `sbitThreshScanParallel.py`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This was requested in https://github.com/cms-gem-daq-project/ctp7_modules/issues/154

## How Has This Been Tested?
Yes, I performed an sbitThresh scan with the waitTime set to 1000 and the waitTime set to 10000, and found the rates were very close while the second scan took around 10 times longer.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
