### PR TITLE
[Bug Fix]: vfatConfig and armDac arguments were missing in iterative trimmer

### DIFF
--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -199,7 +199,7 @@ if __name__ == '__main__':
 
     if args.vfatConfig is not None:
         try:
-            print 'Configuring VFAT Registers based on %s'%args.vfatConfig
+            print('Configuring VFAT Registers based on {0}'.format(args.vfatConfig))
             vfatTree = r.TTree('vfatTree','Tree holding VFAT Configuration Parameters')
             vfatTree.ReadFile(args.vfatConfig)
             
@@ -209,11 +209,11 @@ if __name__ == '__main__':
                     continue
                     
                 # Write CFG_THR_ARM_DAC
-                print('Set link %d VFAT%d CFG_THR_ARM_DAC to %i'%(args.link,event.vfatN,event.vt1))
+                print('Set link {0} VFAT{1} CFG_THR_ARM_DAC to {2}'.format(args.link,event.vfatN,event.vt1))
                 vfatBoard.setVFATThreshold(chip=int(event.vfatN), vt1=int(event.vt1))
         except IOError as e:
-            print '%s does not seem to exist or is not readable'%options.filename
-            print e
+            print('{0} does not seem to exist or is not readable'.format(options.filename))
+            print(e)
     else:
         vfatBoard.setVFATThresholdAll(mask=args.vfatmask, vt1=args.armDAC)
     

--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -203,7 +203,7 @@ if __name__ == '__main__':
             vfatTree = r.TTree('vfatTree','Tree holding VFAT Configuration Parameters')
             vfatTree.ReadFile(args.vfatConfig)
             
-            for event in vfatTree :
+            for event in vfatTree:
                 # Skip masked vfats
                 if (args.vfatmask >> int(event.vfatN)) & 0x1:
                     continue
@@ -212,8 +212,9 @@ if __name__ == '__main__':
                 print('Set link {0} VFAT{1} CFG_THR_ARM_DAC to {2}'.format(args.link,event.vfatN,event.vt1))
                 vfatBoard.setVFATThreshold(chip=int(event.vfatN), vt1=int(event.vt1))
         except IOError as e:
-            print('{0} does not seem to exist or is not readable'.format(options.filename))
+            print('{0} does not seem to exist or is not readable'.format(args.vfatConfig))
             print(e)
+
     else:
         vfatBoard.setVFATThresholdAll(mask=args.vfatmask, vt1=args.armDAC)
     

--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -172,7 +172,9 @@ if __name__ == '__main__':
     parser.add_argument("-p","--pulseStretch", type=int, help="CFG_PULSE_STRETCH value to be used",default=3)
     parser.add_argument("-v","--vfatmask",type=parseInt,default=0x0,help="Specifies which VFATs, if any, should be masked.  Here this is a 24 bit number, where a 1 in the N^th bit means ignore the N^th VFAT.")
     parser.add_argument("-z","--zeroChan",action="store_true",help="Zero all channel registers before beginning iterative trim procedure")
-
+    parser.add_argument("--armDAC", type=int, default = 100,help="CFG_THR_ARM_DAC value to write to all VFATs", metavar="armDAC")
+    parser.add_argument("--vfatConfig", type=str, default=None,help="Specify file containing VFAT settings from anaUltraThreshold", metavar="vfatConfig")
+    
     args = parser.parse_args()
 
     # make scandir
@@ -195,6 +197,26 @@ if __name__ == '__main__':
     vfatBoard = HwVFAT(cardName, args.link, args.debug)
     print("Opened connection")
 
+    if args.vfatConfig is not None:
+        try:
+            print 'Configuring VFAT Registers based on %s'%args.vfatConfig
+            vfatTree = r.TTree('vfatTree','Tree holding VFAT Configuration Parameters')
+            vfatTree.ReadFile(args.vfatConfig)
+            
+            for event in vfatTree :
+                # Skip masked vfats
+                if (args.vfatmask >> int(event.vfatN)) & 0x1:
+                    continue
+                    
+                # Write CFG_THR_ARM_DAC
+                print('Set link %d VFAT%d CFG_THR_ARM_DAC to %i'%(args.link,event.vfatN,event.vt1))
+                vfatBoard.setVFATThreshold(chip=int(event.vfatN), vt1=int(event.vt1))
+        except IOError as e:
+            print '%s does not seem to exist or is not readable'%options.filename
+            print e
+    else:
+        vfatBoard.setVFATThresholdAll(mask=args.vfatmask, vt1=args.armDAC)
+    
     # Get all chip IDs
     vfatIDvals = vfatBoard.getAllChipIDs(args.vfatmask)
 


### PR DESCRIPTION
This pull requests adds `vfatConfig` and `armDAC` arguments to `iterativeTrim.py` and handles them properly.

## Description
The `armDAC` argument takes precedence over the `vfatConfig` argument. `run_scans.py` is automatically checking for vfat config files in a standard location with a standard name when `armDAC` is not provided.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
When installing a software update on the QC7/8 machines, it was reported that `run_scans.py` was passing `--vfatConfig` to `iterativeTrim.py`, which was causing a crash.

## How Has This Been Tested?
Yes, I ran iterative trim runs with both the `--vfatConfig` and the `--armDAC` arguments on the coffin.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
