### PR TITLE
Handle bad DAC fit exceptions in testConnectivity.py

### DIFF
--- a/testConnectivity.py
+++ b/testConnectivity.py
@@ -194,6 +194,8 @@ def testConnectivity(args):
     from gempython.vfatqc.utils.qcutilities import getCardName
     if hasattr(args, 'acceptBadDACBiases') is False: # Accept Bad cases where a VFAT DAC cannot reach correct bias voltage/current
         args.acceptBadDACBiases = False
+    if hasattr(args, 'acceptBadDACFits') is False: # Accept Bad cases where a VFAT DAC cannot reach correct bias voltage/current
+        args.acceptBadDACFits = False        
     if hasattr(args, 'acceptBadTrigLink') is False: # Accept Bad Trigger Link Status?
         args.acceptBadTrigLink = False
     if hasattr(args, 'assignXErrors') is False: # For DAC Scan Analysis
@@ -873,8 +875,18 @@ def testConnectivity(args):
         # Analyze DAC Scan
         from gempython.gemplotting.utils.anautilities import dacAnalysis
         from gempython.gemplotting.utils.exceptions import VFATDACBiasCannotBeReached
+        from gempython.gemplotting.utils.exceptions import VFATDACFitLargeChisquare        
         try:
             dacAnalysis(args, calTree.gemTree, chamber_config, scandate=startTime)
+        except VFATDACFitLargeChisquare as e:
+            printRed("One or more VFATs has a bad (large chisquare) DAC vs ADC fit")
+            printRed(e.message)
+            if not args.acceptBadDACFits:
+                printRed("DAC Scan Analysis Failed")
+                printRed("Conncetivity Testing Failed")
+                return
+            else:
+                printYellow("I've been told to ignore cases of VFATs having bad DAC vs ADC fits; results may not be so good")            
         except VFATDACBiasCannotBeReached as e:
             printRed("One or more VFATs is unable to reach the correct bias voltage/current setpoint")
             printRed(e.message)
@@ -1147,6 +1159,7 @@ if __name__ == '__main__':
     parser.add_argument("--checkCSCTrigLink",action="store_true",help="Check also the trigger link for the CSC trigger associated to OH in mask")
     parser.add_argument("--deadChanCuts",type=str,help="Comma separated pair of integers specifying in fC the scurve width to consider a channel dead",default="0.1,0.5")
     parser.add_argument("--acceptBadDACBiases",action="store_true",help="Ignore failures where a VFAT DAC cannot reach the correct bias voltage/current")
+    parser.add_argument("--acceptBadDACFits",action="store_true",help="Ignore cases where a VFAT DAC vs ADC fit has a large chisquare")    
     parser.add_argument("-a","--acceptBadTrigLink",action="store_true",help="Ignore failing trigger link status checks")
     parser.add_argument("-d","--debug",action="store_true",dest="debug",help = "Print additional debugging information")
     parser.add_argument("--detType",type=str,help="Detector type within gemType. If gemType is 'ge11' then this should be from list {0}; if gemType is 'ge21' then this should be from list {1}; and if type is 'me0' then this should be from the list {2}".format(gemVariants['ge11'],gemVariants['ge21'],gemVariants['me0']),default=None)


### PR DESCRIPTION
This pull request makes the changes to `vfatqc-python-scripts` that go along with the changes to `gem-plotting-tools` in https://github.com/cms-gem-daq-project/gem-plotting-tools/pull/260

## Description
This pull request updates `testConnectivity.py` to handle the new exceptions that are thrown when there is a large chisquare value for a DAC vs ADC fit. The default behavior is to exit, but there is a a flag that can be passed to `testConnectivity.py` that tells it to ignore these exceptions.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
We are mainly using `testConnectivity.py` to run DAC scans now.

## How Has This Been Tested?
Yes, I tested it on the coffin, with and without the option `--acceptBadDACFits`, and found the expected behavior in both cases

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
