### PR TITLE
[new feature] Add new features to iterative trimmer

### DIFF
--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
 
     from gempython.gemplotting.utils.scanInfo  import sigmaOffsetDefault, highTrimCutoffDefault, highTrimWeightDefault, highNoiseCutDefault
     
-    parser.add_argument("--sigmaOffset", type=float, help="Will align the mean - sigmaOffset*sigma", sigmaOffsetDefault)
+    parser.add_argument("--sigmaOffset", type=float, help="Will align the mean + sigmaOffset*sigma", sigmaOffsetDefault)
     parser.add_argument("--highTrimCutoff", type=float, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", highTrimCutoffDefault)
     parser.add_argument("--highTrimWeight", type=float, help="Will apply this weight to channels that have a trim value above the cutoff", highTrimWeightDefault)    
     parser.add_argument("--highNoiseCut", type=float, help="Threshold in fC for masking the channel due to high noise", default=highNoiseCutDefault)

--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -357,7 +357,7 @@ if __name__ == '__main__':
 
             # See equation on step 3 of:
             # https://indico.cern.ch/event/838248/contributions/3515801/attachments/1887448/3112771/VFAT3b_trim.pdf
-            trimDeltas = np.round(weightedMean - (scurveFitResults[0][vfat]+args.sigmaOffset*scurveFitResults[1][vfat])) * 15
+            trimDeltas = np.round((weightedMean - (scurveFitResults[0][vfat]+args.sigmaOffset*scurveFitResults[1][vfat])) * 15)
 
             # Determine number of trimmed channels (e.g. trimDeltas == 0)
             uniqueVals, counts = np.unique(trimDeltas, return_counts=True)

--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -171,12 +171,12 @@ if __name__ == '__main__':
 
     from gempython.gemplotting.utils.scanInfo  import sigmaOffsetDefault, highTrimCutoffDefault, highTrimWeightDefault, highNoiseCutDefault
     
-    parser.add_argument("--sigmaOffset", type=float, help="Will align the mean + sigmaOffset*sigma", sigmaOffsetDefault)
-    parser.add_argument("--highTrimCutoff", type=float, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", highTrimCutoffDefault)
-    parser.add_argument("--highTrimWeight", type=float, help="Will apply this weight to channels that have a trim value above the cutoff", highTrimWeightDefault)    
+    parser.add_argument("--sigmaOffset", type=float, help="Will align the mean + sigmaOffset*sigma", default=sigmaOffsetDefault)
+    parser.add_argument("--highTrimCutoff", type=float, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", default=highTrimCutoffDefault)
+    parser.add_argument("--highTrimWeight", type=float, help="Will apply this weight to channels that have a trim value above the cutoff", default=highTrimWeightDefault)    
     parser.add_argument("--highNoiseCut", type=float, help="Threshold in fC for masking the channel due to high noise", default=highNoiseCutDefault)
     
-    parser.add_argument("-n","--nevts",type=int,default=100,help="Number of events for each scan position")
+#    parser.add_argument("-n","--nevts",type=int,default=100,help="Number of events for each scan position")
     parser.add_argument("-p","--pulseStretch", type=int, help="CFG_PULSE_STRETCH value to be used",default=3)
     parser.add_argument("-v","--vfatmask",type=parseInt,default=0x0,help="Specifies which VFATs, if any, should be masked.  Here this is a 24 bit number, where a 1 in the N^th bit means ignore the N^th VFAT.")
     parser.add_argument("-z","--zeroChan",action="store_true",help="Zero all channel registers before beginning iterative trim procedure")

--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -176,7 +176,7 @@ if __name__ == '__main__':
     parser.add_argument("--highTrimWeight", type=float, help="Will apply this weight to channels that have a trim value above the cutoff", default=highTrimWeightDefault)    
     parser.add_argument("--highNoiseCut", type=float, help="Threshold in fC for masking the channel due to high noise", default=highNoiseCutDefault)
     
-#    parser.add_argument("-n","--nevts",type=int,default=100,help="Number of events for each scan position")
+    parser.add_argument("-n","--nevts",type=int,default=100,help="Number of events for each scan position")
     parser.add_argument("-p","--pulseStretch", type=int, help="CFG_PULSE_STRETCH value to be used",default=3)
     parser.add_argument("-v","--vfatmask",type=parseInt,default=0x0,help="Specifies which VFATs, if any, should be masked.  Here this is a 24 bit number, where a 1 in the N^th bit means ignore the N^th VFAT.")
     parser.add_argument("-z","--zeroChan",action="store_true",help="Zero all channel registers before beginning iterative trim procedure")

--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -307,10 +307,17 @@ if __name__ == '__main__':
 
             toAlignValues = []
             toAlignWeights = []            
+            channelMasks = []
+            channelMaskReasons = []
             
             for ch in range(0,128):
                 if scurveFitResults[1][vfat][ch] > args.highNoiseCut:
+                    channelMasks.append(1)
+                    channelMaskReasons.append(0x08)
                     continue
+                else:
+                    channelMasks.append(0)
+                    channelMaskReasons.append(0)
                 
                 if iterNum > 1 and lastTrimDACs[ch] > args.highTrimCutoff: 
                     toAlignValues.append(scurveFitResults[0][vfat][ch] + args.sigmaOffset*scurveFitResults[1][vfat][ch])
@@ -415,7 +422,7 @@ if __name__ == '__main__':
                     ignore_index=True)
 
             # Write this info to chConfig file
-            writeChConfig(chConfig,vfat,vfatIDvals[vfat],currentTrimDACs,currentTrimPols,dict_chanRegArray[iterNum]["MASK"][vfat*128:(vfat+1)*128],arrayMaskReason[vfat*128:(vfat+1)*128])
+            writeChConfig(chConfig,vfat,vfatIDvals[vfat],currentTrimDACs,currentTrimPols,channelMasks,channelMaskReasons)
             pass # end loop over VFATs
 
         chConfig.close()

--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -172,7 +172,7 @@ if __name__ == '__main__':
     from gempython.gemplotting.utils.scanInfo  import sigmaOffsetDefault, highTrimCutoffDefault, highTrimWeightDefault, highNoiseCutDefault
     
     parser.add_argument("--sigmaOffset", type=float, help="Will align the mean + sigmaOffset*sigma", default=sigmaOffsetDefault)
-    parser.add_argument("--highTrimCutoff", type=float, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", default=highTrimCutoffDefault)
+    parser.add_argument("--highTrimCutoff", type=int, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", default=highTrimCutoffDefault)
     parser.add_argument("--highTrimWeight", type=float, help="Will apply this weight to channels that have a trim value above the cutoff", default=highTrimWeightDefault)    
     parser.add_argument("--highNoiseCut", type=float, help="Threshold in fC for masking the channel due to high noise", default=highNoiseCutDefault)
     

--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -169,7 +169,7 @@ if __name__ == '__main__':
     parser.add_argument("-l","--latency", type=int, help="CFG_LATENCY value to be used",default=33)
     parser.add_argument("-m","--maxIter", type=int, help="Maximum number of iterations to perform (e.g. number of scurves to take)", default=4)
 
-    from gempython.gemplotting.utils.scanInfo  import sigmaOffsetDefault, highTrimCutoffDefault, highTrimWeightDefault, highNoiseCutDefault
+    from gempython.vfatqc.utils.scanInfo  import sigmaOffsetDefault, highTrimCutoffDefault, highTrimWeightDefault, highNoiseCutDefault
     
     parser.add_argument("--sigmaOffset", type=float, help="Will align the mean + sigmaOffset*sigma", default=sigmaOffsetDefault)
     parser.add_argument("--highTrimCutoff", type=int, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", default=highTrimCutoffDefault)

--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -168,11 +168,13 @@ if __name__ == '__main__':
     parser.add_argument("-d","--debug", action="store_true", help="Prints additional debugging information")
     parser.add_argument("-l","--latency", type=int, help="CFG_LATENCY value to be used",default=33)
     parser.add_argument("-m","--maxIter", type=int, help="Maximum number of iterations to perform (e.g. number of scurves to take)", default=4)
+
+    from gempython.gemplotting.utils.scanInfo  import sigmaOffsetDefault, highTrimCutoffDefault, highTrimWeightDefault, highNoiseCutDefault
     
-    parser.add_argument("--sigmaOffset", type=int, help="Will align the mean - sigmaOffset*sigma", default=0)
-    parser.add_argument("--highTrimCutoff", type=int, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", default=63)
-    parser.add_argument("--highTrimWeight", type=int, help="Will apply this weight to channels that have a trim value above the cutoff", default=50)    
-    parser.add_argument("--highNoiseCut", type=float, default=1.5, help="Threshold in fC for masking the channel due to high noise")
+    parser.add_argument("--sigmaOffset", type=float, help="Will align the mean - sigmaOffset*sigma", sigmaOffsetDefault)
+    parser.add_argument("--highTrimCutoff", type=float, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", highTrimCutoffDefault)
+    parser.add_argument("--highTrimWeight", type=float, help="Will apply this weight to channels that have a trim value above the cutoff", highTrimWeightDefault)    
+    parser.add_argument("--highNoiseCut", type=float, help="Threshold in fC for masking the channel due to high noise", default=highNoiseCutDefault)
     
     parser.add_argument("-n","--nevts",type=int,default=100,help="Number of events for each scan position")
     parser.add_argument("-p","--pulseStretch", type=int, help="CFG_PULSE_STRETCH value to be used",default=3)

--- a/run_scans.py
+++ b/run_scans.py
@@ -795,7 +795,7 @@ if __name__ == '__main__':
     from gempython.gemplotting.utils.scanInfo  import sigmaOffsetDefault, highTrimCutoffDefault, highTrimWeightDefault, highNoiseCutDefault
     
     parser_itertrim.add_argument("--sigmaOffset", type=float, help="Will align the mean + sigmaOffset*sigma", default=sigmaOffsetDefault)
-    parser_itertrim.add_argument("--highTrimCutoff", type=float, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", default=highTrimCutoffDefault)
+    parser_itertrim.add_argument("--highTrimCutoff", type=int, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", default=highTrimCutoffDefault)
     parser_itertrim.add_argument("--highTrimWeight", type=float, help="Will apply this weight to channels that have a trim value above the cutoff", default=highTrimWeightDefault)
     parser_itertrim.add_argument("--highNoiseCut", type=float, help="Threshold in fC for masking the channel due to high noise",default=highNoiseCutDefault)
     

--- a/run_scans.py
+++ b/run_scans.py
@@ -792,10 +792,12 @@ if __name__ == '__main__':
     parser_itertrim.add_argument("--vfatmask",type=parseInt,default=None,help="If specified this will use this VFAT mask for all unmasked OH's in ohMask.  Here this is a 24 bit number, where a 1 in the N^th bit means ignore the N^th VFAT.  If this argument is not specified VFAT masks are determined at runtime automatically.")
     parser_itertrim.add_argument("--armDAC",type=int,help="CFG_THR_ARM_DAC value to write to all VFATs. If not provided we will look under $DATA_PATH/configs for a vfatConfig_<DetectorName>.txt file where DetectorNames are from the chamber_config dictionary")
 
-    parser_itertrim.add_argument("--sigmaOffset", type=int, help="Will align the mean - sigmaOffset*sigma", default=0)
-    parser_itertrim.add_argument("--highTrimCutoff", type=int, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", default=63)
-    parser_itertrim.add_argument("--highTrimWeight", type=int, help="Will apply this weight to channels that have a trim value above the cutoff", default=50)
-    parser_itertrim.add_argument("--highNoiseCut", type=float, default=1.5, help="Threshold in fC for masking the channel due to high noise")
+    om gempython.gemplotting.utils.scanInfo  import sigmaOffsetDefault, highTrimCutoffDefault, highTrimWeightDefault, highNoiseCutDefault
+    
+    parser_itertrim.add_argument("--sigmaOffset", type=float, help="Will align the mean - sigmaOffset*sigma", default=sigmaOffsetDefault)
+    parser_itertrim.add_argument("--highTrimCutoff", type=float, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", default=highTrimCutoffDefault)
+    parser_itertrim.add_argument("--highTrimWeight", type=float, help="Will apply this weight to channels that have a trim value above the cutoff", default=highTrimWeightDefault)
+    parser_itertrim.add_argument("--highNoiseCut", type=float, help="Threshold in fC for masking the channel due to high noise",default=highNoiseCutDefault)
     
     parser_itertrim.set_defaults(func=iterTrim)
     

--- a/run_scans.py
+++ b/run_scans.py
@@ -792,9 +792,9 @@ if __name__ == '__main__':
     parser_itertrim.add_argument("--vfatmask",type=parseInt,default=None,help="If specified this will use this VFAT mask for all unmasked OH's in ohMask.  Here this is a 24 bit number, where a 1 in the N^th bit means ignore the N^th VFAT.  If this argument is not specified VFAT masks are determined at runtime automatically.")
     parser_itertrim.add_argument("--armDAC",type=int,help="CFG_THR_ARM_DAC value to write to all VFATs. If not provided we will look under $DATA_PATH/configs for a vfatConfig_<DetectorName>.txt file where DetectorNames are from the chamber_config dictionary")
 
-    om gempython.gemplotting.utils.scanInfo  import sigmaOffsetDefault, highTrimCutoffDefault, highTrimWeightDefault, highNoiseCutDefault
+    from gempython.gemplotting.utils.scanInfo  import sigmaOffsetDefault, highTrimCutoffDefault, highTrimWeightDefault, highNoiseCutDefault
     
-    parser_itertrim.add_argument("--sigmaOffset", type=float, help="Will align the mean - sigmaOffset*sigma", default=sigmaOffsetDefault)
+    parser_itertrim.add_argument("--sigmaOffset", type=float, help="Will align the mean + sigmaOffset*sigma", default=sigmaOffsetDefault)
     parser_itertrim.add_argument("--highTrimCutoff", type=float, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", default=highTrimCutoffDefault)
     parser_itertrim.add_argument("--highTrimWeight", type=float, help="Will apply this weight to channels that have a trim value above the cutoff", default=highTrimWeightDefault)
     parser_itertrim.add_argument("--highNoiseCut", type=float, help="Threshold in fC for masking the channel due to high noise",default=highNoiseCutDefault)

--- a/run_scans.py
+++ b/run_scans.py
@@ -468,6 +468,10 @@ def iterTrim(args):
                 "--maxIter={}".format(args.maxIter),
                 "--nevts={}".format(args.nevts),
                 "--vfatmask=0x{:x}".format(args.vfatmask if (args.vfatmask is not None) else amcBoard.getLinkVFATMask(ohN) ),
+                "--sigmaOffset={}".format(args.sigmaOffset),
+                "--highTrimCutoff={}".format(args.highTrimCutoff),
+                "--highTrimWeight={}".format(args.highTrimWeight),
+                "--highNoiseCut={}".format(args.highNoiseCut)                
                 ]
 
         # debug flag raised?
@@ -788,6 +792,11 @@ if __name__ == '__main__':
     parser_itertrim.add_argument("--vfatmask",type=parseInt,default=None,help="If specified this will use this VFAT mask for all unmasked OH's in ohMask.  Here this is a 24 bit number, where a 1 in the N^th bit means ignore the N^th VFAT.  If this argument is not specified VFAT masks are determined at runtime automatically.")
     parser_itertrim.add_argument("--armDAC",type=int,help="CFG_THR_ARM_DAC value to write to all VFATs. If not provided we will look under $DATA_PATH/configs for a vfatConfig_<DetectorName>.txt file where DetectorNames are from the chamber_config dictionary")
 
+    parser_itertrim.add_argument("--sigmaOffset", type=int, help="Will align the mean - sigmaOffset*sigma", default=0)
+    parser_itertrim.add_argument("--highTrimCutoff", type=int, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", default=63)
+    parser_itertrim.add_argument("--highTrimWeight", type=int, help="Will apply this weight to channels that have a trim value above the cutoff", default=50)
+    parser_itertrim.add_argument("--highNoiseCut", type=float, default=1.5, help="Threshold in fC for masking the channel due to high noise")
+    
     parser_itertrim.set_defaults(func=iterTrim)
     
     # Check env

--- a/run_scans.py
+++ b/run_scans.py
@@ -792,7 +792,7 @@ if __name__ == '__main__':
     parser_itertrim.add_argument("--vfatmask",type=parseInt,default=None,help="If specified this will use this VFAT mask for all unmasked OH's in ohMask.  Here this is a 24 bit number, where a 1 in the N^th bit means ignore the N^th VFAT.  If this argument is not specified VFAT masks are determined at runtime automatically.")
     parser_itertrim.add_argument("--armDAC",type=int,help="CFG_THR_ARM_DAC value to write to all VFATs. If not provided we will look under $DATA_PATH/configs for a vfatConfig_<DetectorName>.txt file where DetectorNames are from the chamber_config dictionary")
 
-    from gempython.gemplotting.utils.scanInfo  import sigmaOffsetDefault, highTrimCutoffDefault, highTrimWeightDefault, highNoiseCutDefault
+    from gempython.vfatqc.utils.scanInfo  import sigmaOffsetDefault, highTrimCutoffDefault, highTrimWeightDefault, highNoiseCutDefault
     
     parser_itertrim.add_argument("--sigmaOffset", type=float, help="Will align the mean + sigmaOffset*sigma", default=sigmaOffsetDefault)
     parser_itertrim.add_argument("--highTrimCutoff", type=int, help="Will weight channels that have a trim value above this (when set to 63, has no effect)", default=highTrimCutoffDefault)

--- a/utils/scanInfo.py
+++ b/utils/scanInfo.py
@@ -1,0 +1,17 @@
+r"""
+``scanInfo`` --- Scan information
+====================================
+
+.. code-block:: python
+
+    import gempython.vfatqc.utils.scanInfo
+
+Documentation
+-------------
+"""
+
+#default values for the algorithm to update the trim values in the iterative trimmer
+sigmaOffsetDefault=0
+highNoiseCutDefault=63
+highTrimCutoffDefault=50
+highTrimWeightDefault=1.5


### PR DESCRIPTION
Adds four new arguments to the iterative trimmer that turn on and adjust special features:

1.  `sigmaOffset` 
2. `highNoiseCut`
3. `highTrimCutoff`
4. `highTrimWeight`

## Description
The iterative trimming algorithm now does the following at each iteration:

1. Take an scurve

2. For each channel such that noise is less than `highNoiseCut`, calculate the following quanity: scurve mean plus `sigmaOffset` times scurve sigma

3. Take the weighted average of these quantities, where the weight equals 1 if the trim setting from the previous iteration is less than or equal to `highTrimCutoff`, and equals `highTrimWeight` if the trim setting from the previous iteration is greater than `highTrimCutoff`.

4. Use the formula 15 times difference from weighted average to set the trim settings for the next iteration.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This was requested by the QC8 team: https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/283

## How Has This Been Tested?
I have used it to trim the coffin with three iterations and found the final scurves look similar to previous trimmed scurves on the coffin:

![Summary](https://user-images.githubusercontent.com/3329216/68397209-172e5280-0173-11ea-9196-d50f1cdb77bc.png)

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
