### PR TITLE
Make `getCalInfoFromDB.py` install the correct `VREF_ADC` values

### DIFF
--- a/getCalInfoFromDB.py
+++ b/getCalInfoFromDB.py
@@ -8,7 +8,7 @@ if __name__ == '__main__':
     parser.add_argument("link",type=int,help="OH on AMC slot")
     parser.add_argument("-d","--debug",action="store_true",help="Prints additional information")
     parser.add_argument("--write2File",action="store_true",help="If Provided data will be written to appropriate calibration files")
-    parser.add_argument("--write2CTP7",action="store_true",help="If Provided IREF data will be sent to the VFAT3 config files on the CTP7")
+    parser.add_argument("--write2CTP7",action="store_true",help="If Provided VREF_ADC and IREF data will be sent to the VFAT3 config files on the CTP7")
     args = parser.parse_args()
 
     from gempython.tools.vfat_user_functions_xhal import *
@@ -50,6 +50,20 @@ if __name__ == '__main__':
 
     # Write calibration info to disk?
     if args.write2File:
+        from gempython.utils.wrappers import runCommand
+
+        # Write VREF_ADC Info
+        filename_vref_adc = "{0}/NominalValues-CFG_VREF_ADC.txt".format(outDir)
+        print("Writing 'CFG_VREF_ADC' to file: {0}".format(filename_vref_adc))
+        dbInfo.to_csv(
+                path_or_buf=filename_vref_adc,
+                sep="\t",
+                columns=['vfatN','vref_adc'],
+                header=False,
+                index=False,
+                mode='w')
+        runCommand(["chmod", "g+rw", filename_vref_adc])
+
         # Write IREF Info
         filename_iref = "{0}/NominalValues-CFG_IREF.txt".format(outDir)
         print("Writing 'CFG_IREF' to file: {0}".format(filename_iref))
@@ -60,7 +74,6 @@ if __name__ == '__main__':
                 header=False,
                 index=False,
                 mode='w')
-        from gempython.utils.wrappers import runCommand
         runCommand(["chmod", "g+rw", filename_iref])
 
         # Write ADC0 Info
@@ -92,12 +105,26 @@ if __name__ == '__main__':
         runCommand(["chmod", "g+rw", filename_caldac])
         pass
 
-    # Write CFG_IREF to VFAT3 Config Files On CTP7?    
+    # Write CFG_VREF_ADC and CFG_IREF to VFAT3 Config Files On CTP7?
     if args.write2CTP7:
         import os
+        from gempython.utils.wrappers import runCommand
+
+        filename_vref_adc = "{0}/NominalValues-CFG_VREF_ADC.txt".format(outDir)
+        if not os.path.isfile(filename_vref_adc):
+            print("Writing 'CFG_VREF_ADC' to file: {0}".format(filename_vref_adc))
+            dbInfo.to_csv(
+                    path_or_buf=filename_vref_adc,
+                    sep="\t",
+                    columns=['vfatN','vref_adc'],
+                    header=False,
+                    index=False,
+                    mode='w')
+            runCommand(["chmod", "g+rw", filename_vref_adc])
+            pass
+
         filename_iref = "{0}/NominalValues-CFG_IREF.txt".format(outDir)
         if not os.path.isfile(filename_iref):
-            filename_iref = "{0}/NominalValues-CFG_IREF.txt".format(outDir)
             print("Writing 'CFG_IREF' to file: {0}".format(filename_iref))
             dbInfo.to_csv(
                     path_or_buf=filename_iref,
@@ -106,7 +133,6 @@ if __name__ == '__main__':
                     header=False,
                     index=False,
                     mode='w')
-            from gempython.utils.wrappers import runCommand
             runCommand(["chmod", "g+rw", filename_iref])
             pass
 
@@ -117,6 +143,7 @@ if __name__ == '__main__':
     
         from gempython.vfatqc.utils.confUtils import updateVFAT3ConfFilesOnAMC
         updateVFAT3ConfFilesOnAMC(cardName,args.link,filename_iref,"CFG_IREF")
+        updateVFAT3ConfFilesOnAMC(cardName,args.link,filename_vref_adc,"CFG_VREF_ADC")
         pass
 
     print("goodbye")

--- a/getCalInfoFromDB.py
+++ b/getCalInfoFromDB.py
@@ -8,8 +8,13 @@ if __name__ == '__main__':
     parser.add_argument("link",type=int,help="OH on AMC slot")
     parser.add_argument("-d","--debug",action="store_true",help="Prints additional information")
     parser.add_argument("--write2File",action="store_true",help="If Provided data will be written to appropriate calibration files")
-    parser.add_argument("--write2CTP7",action="store_true",help="If Provided VREF_ADC and IREF data will be sent to the VFAT3 config files on the CTP7")
+    parser.add_argument("--write2CTP7",action="store_true",help="If Provided VREF_ADC and IREF data will be sent to the VFAT3 config files on the CTP7 (implies --write2File)")
     args = parser.parse_args()
+
+    # Update the files on the DAQ machine whenever an update on the CTP7 is requested
+    # This avoids sending stale data on the CTP7 if --write2File is not set
+    if args.write2CTP7:
+        args.write2File = True
 
     from gempython.tools.vfat_user_functions_xhal import *
     
@@ -35,11 +40,14 @@ if __name__ == '__main__':
     dbInfo.info()
     print(dbInfo)
 
-    if args.write2File or args.write2CTP7:
+    # Write calibration info to disk?
+    if args.write2File:
         from gempython.gemplotting.utils.anautilities import getDataPath, getElogPath
-        ohKey = (args.shelf, args.slot, args.link)
-        
         from gempython.gemplotting.mapping.chamberInfo import chamber_config
+        from gempython.utils.wrappers import runCommand
+
+        ohKey = (args.shelf, args.slot, args.link)
+
         if ohKey in chamber_config:
             cName = chamber_config[ohKey]
             outDir="{0}/{1}".format(getDataPath(),chamber_config[ohKey])
@@ -47,10 +55,6 @@ if __name__ == '__main__':
             cName = "Detector"
             outDir=getElogPath()
             pass
-
-    # Write calibration info to disk?
-    if args.write2File:
-        from gempython.utils.wrappers import runCommand
 
         # Write VREF_ADC Info
         filename_vref_adc = "{0}/NominalValues-CFG_VREF_ADC.txt".format(outDir)
@@ -107,35 +111,6 @@ if __name__ == '__main__':
 
     # Write CFG_VREF_ADC and CFG_IREF to VFAT3 Config Files On CTP7?
     if args.write2CTP7:
-        import os
-        from gempython.utils.wrappers import runCommand
-
-        filename_vref_adc = "{0}/NominalValues-CFG_VREF_ADC.txt".format(outDir)
-        if not os.path.isfile(filename_vref_adc):
-            print("Writing 'CFG_VREF_ADC' to file: {0}".format(filename_vref_adc))
-            dbInfo.to_csv(
-                    path_or_buf=filename_vref_adc,
-                    sep="\t",
-                    columns=['vfatN','vref_adc'],
-                    header=False,
-                    index=False,
-                    mode='w')
-            runCommand(["chmod", "g+rw", filename_vref_adc])
-            pass
-
-        filename_iref = "{0}/NominalValues-CFG_IREF.txt".format(outDir)
-        if not os.path.isfile(filename_iref):
-            print("Writing 'CFG_IREF' to file: {0}".format(filename_iref))
-            dbInfo.to_csv(
-                    path_or_buf=filename_iref,
-                    sep="\t",
-                    columns=['vfatN','iref'],
-                    header=False,
-                    index=False,
-                    mode='w')
-            runCommand(["chmod", "g+rw", filename_iref])
-            pass
-
         from gempython.utils.gemlogger import getGEMLogger
         import logging
         gemlogger = getGEMLogger(__name__)


### PR DESCRIPTION
## Description
[Requires cms-gem-daq-project/gem-plotting-tools#264.]

This PR allows `getCalInfoFromDB.py` to install the `VREF_ADC` values on the CTP7 after a query to the database.

Once merged, the following procedure should allow a seamless operation at P5 regarding the DAC configuration:

1. Launch `testConnectivity.py` to establish the communication with the frontend (flags `--skipDACScan` and `--skipScurve`).
 2. Update all the configuration files with the information from the DB with `getCalInfoFromDB.py` (flags `--write2CTP7` and `--write2File`).
3. Restart `testConnectivity.py` where it was stopped with the flag `-f5`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

DAC scan failures encountered during commissioning at P5.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`VREF_ADC` values are correctly written to files in the `$GEM_PATH` and on the CTP7.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
