### PR TITLE
Fix GEM variant/GEB type bug

### DIFF
--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -426,7 +426,9 @@ if __name__ == '__main__':
             chConfig.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:trimPolarity/I:mask/I:maskReason/I\n')
 
             # Define current channel register array container
-            currentChanRegArray = np.zeros(vfatsPerGemVariant[GEBtype[ohKey]]*CHANNELS_PER_VFAT, dtype=dataType)
+            detName = chamber_config[ohKey]
+            gemType = detName[:detName.find('-')].lower()            
+            currentChanRegArray = np.zeros(vfatsPerGemVariant[gemType]*CHANNELS_PER_VFAT, dtype=dataType)
             for entry in dataType:
                 if ((entry[0] == "ARM_TRIM_POLARITY") or (entry[0] == "ARM_TRIM_AMPLITUDE")):
                     continue

--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -54,10 +54,12 @@ def iterativeTrim(args,dict_dirPaths,identifier,dict_chanRegData=None,dict_calFi
             cArray_trimPol = None
         else:
             setChanRegs = True
-            cArray_trimVal = (c_uint32*vfatsPerGemVariant[GEBtype[ohKey]]*CHANNELS_PER_VFAT)(*dict_chanRegData[ohN]["ARM_TRIM_AMPLITUDE"])
-            cArray_trimPol = (c_uint32*vfatsPerGemVariant[GEBtype[ohKey]]*CHANNELS_PER_VFAT)(*dict_chanRegData[ohN]["ARM_TRIM_POLARITY"])
+            detName = chamber_config[ohKey]
+            gemType = detName[:detName.find('-')].lower()
+            cArray_trimVal = (c_uint32*vfatsPerGemVariant[gemType]*CHANNELS_PER_VFAT)(*dict_chanRegData[ohN]["ARM_TRIM_AMPLITUDE"])
+            cArray_trimPol = (c_uint32*vfatsPerGemVariant[gemType]*CHANNELS_PER_VFAT)(*dict_chanRegData[ohN]["ARM_TRIM_POLARITY"])
             pass
-        
+
         # Set filename of this scurve
         isZombie = True
         filename = "{:s}/SCurveData_{:s}.root".format(dict_dirPaths[ohN],identifier)


### PR DESCRIPTION
This fixes a bug where the GEM variant was confused with the GEB type.

## Description
Gets the GEM variant based on the detector name and uses it as the key in the vfatsPerGemVariant dictionary.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Resolves https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/293, although we may want to make a common  `getGemType` function.

## How Has This Been Tested?
I tested just the lines of code that I added.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
