### PR TITLE
Fix c_uint32 array length definition bug

### DIFF
--- a/iterativeTrim.py
+++ b/iterativeTrim.py
@@ -56,8 +56,8 @@ def iterativeTrim(args,dict_dirPaths,identifier,dict_chanRegData=None,dict_calFi
             setChanRegs = True
             detName = chamber_config[ohKey]
             gemType = detName[:detName.find('-')].lower()
-            cArray_trimVal = (c_uint32*vfatsPerGemVariant[gemType]*CHANNELS_PER_VFAT)(*dict_chanRegData[ohN]["ARM_TRIM_AMPLITUDE"])
-            cArray_trimPol = (c_uint32*vfatsPerGemVariant[gemType]*CHANNELS_PER_VFAT)(*dict_chanRegData[ohN]["ARM_TRIM_POLARITY"])
+            cArray_trimVal = (c_uint32*(vfatsPerGemVariant[gemType]*CHANNELS_PER_VFAT))(*dict_chanRegData[ohN]["ARM_TRIM_AMPLITUDE"])
+            cArray_trimPol = (c_uint32*(vfatsPerGemVariant[gemType]*CHANNELS_PER_VFAT))(*dict_chanRegData[ohN]["ARM_TRIM_POLARITY"])
             pass
 
         # Set filename of this scurve


### PR DESCRIPTION
Defines a temporary variable to hold the length of the array instead of performing multiplication inside of the parentheses to calculate the length.

## Description
The syntax used to create an array of `c_uint32`s was not correct because of the additional `*`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Resolves https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/295

## How Has This Been Tested?
Yes, it works in my virtual environment.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
