### PR TITLE
legacy releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ PythonModules = ["$(Namespace).$(ShortPackage)", \
 ]
 $(info PythonModules=${PythonModules})
 
-VFATQC_VER_MAJOR=2
-VFATQC_VER_MINOR=4
-VFATQC_VER_PATCH=3
+VFATQC_VER_MAJOR:=$(shell ./config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
+VFATQC_VER_MINOR:=$(shell ./config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
+VFATQC_VER_PATCH:=$(shell ./config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
 include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
 include $(BUILD_HOME)/$(Project)/config/mfPythonDefs.mk

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -7,6 +7,7 @@ from os.path import isfile,join
 scriptdir  = 'gempython/scripts'
 scriptpath = '/opt/cmsgemos/bin'
 scripts    = listdir(scriptdir)
+mandir     = 'man'
 
 def readme():
     with open('README.md') as f:
@@ -31,8 +32,29 @@ def getreqs():
         reqs = f.readlines()
         return [x.strip() for x in reqs]
 
+def getVersion():
+    __version__='___version___'
+    __release__='___release___'
+    __buildtag__='___buildtag___'
+    __gitrev__='___gitrev___'
+    __gitver__='___gitver___'
+    __packager__='___packager___'
+    __builddate__='___builddate___'
+    with open("gempython/vfatqc/_version.py","w") as verfile:
+        verfile.write("""
+## This file is generated automatically from vfatqc setup.py
+__version__='{0:s}'
+__release__='{1:s}'
+__buildtag__='{2:s}'
+__gitrev__='{3:s}'
+__gitver__='{4:s}'
+__packager__='{5:s}'
+__builddate__='{6:s}'
+""".format(__version__,__release__,__buildtag__,__gitrev__,__gitver__,__packager__,__builddate__))
+    return '{0:s}'.format(__version__)
+
 setup(name             = '__packagename__',
-      version          = '__version__',
+      version          = getVersion(),
       # use_scm_version  = True,
       description      = '__description__',
       long_description = readme(),


### PR DESCRIPTION
Bump `gembuild` submodule to be able to have rpm creation to be the same as other repos, i.e., getting the tag and meta info from the `tag2rel.sh` script

With a tag 2.7.11 one commit behind the build, the change results in:
```
./rpm/gempython_vfatqc-2.7.11-1.0.1.dev.7118576git.centos7.python2.7.noarch.rpm
```
the dirty tagged commit of 2.7.11 results in
```
./rpm/gempython_vfatqc-2.7.11-1.caf96cagit.centos7.python2.7.noarch.rpm
```
compared to the old, hardcoded way
```
./rpm/gempython_vfatqc-2.7.11-centos7.python2.7.x86_64.rpm
```